### PR TITLE
initial working prototype with support for authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+*.py[co]
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+var
+sdist
+develop-eggs
+.installed.cfg
+.eggs
+.eggs*
+
+# Installer logs
+pip-log.txt
+
+*~
+setup.cfg
+
+# Unit test / coverage reports
+.coverage
+.tox
+
+#Translations
+*.mo
+
+#Mr Developer
+.mr.developer.cfg
+
+# Vim
+.*.sw[op]
+
+html
+test-reports
+
+setup.cfg

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Description
+
+Interface to Pacific OceanStor storage API.
+
+Originally created by the HPC team of Vrije Universiteit Brussel (http://hpc.vub.be).
+

--- a/lib/vsc/__init__.py
+++ b/lib/vsc/__init__.py
@@ -1,0 +1,36 @@
+##
+# Copyright 2020-2022 Vrije Universiteit Brussel
+#
+# This file is part of vsc-filesystem-oceanstor,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# updated by the HPC team of Vrij Universiteit Brussel (http://hpc.vub.be),
+# with support of Vrije Universiteit Brussel (http://www.vub.be),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# the Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/vub-hpc/vsc-filesystem-oceanstor
+#
+# vsc-filesystem-oceanstor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation v2.
+#
+# vsc-filesystem-oceanstor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with vsc-manage.  If not, see <http://www.gnu.org/licenses/>.
+#
+##
+"""
+Initialize vsc package.
+The vsc namespace is used in different folders along the system
+so explicitly declare this is also the vsc namespace.
+
+@author: Andy Georges (Ghent University)
+"""
+import pkg_resources
+pkg_resources.declare_namespace(__name__)

--- a/lib/vsc/filesystem/__init__.py
+++ b/lib/vsc/filesystem/__init__.py
@@ -1,0 +1,36 @@
+##
+# Copyright 2020-2022 Vrije Universiteit Brussel
+#
+# This file is part of vsc-filesystem-oceanstor,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# updated by the HPC team of Vrij Universiteit Brussel (http://hpc.vub.be),
+# with support of Vrije Universiteit Brussel (http://www.vub.be),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# the Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/vub-hpc/vsc-filesystem-oceanstor
+#
+# vsc-filesystem-oceanstor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation v2.
+#
+# vsc-filesystem-oceanstor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with vsc-manage.  If not, see <http://www.gnu.org/licenses/>.
+#
+##
+"""
+Initialize vsc package.
+The vsc namespace is used in different folders along the system
+so explicitly declare this is also the vsc namespace.
+
+@author: Andy Georges (Ghent University)
+"""
+import pkg_resources
+pkg_resources.declare_namespace(__name__)

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -1,0 +1,148 @@
+##
+# Copyright 2022 Vrije Universiteit Brussel
+#
+# This file is part of vsc-filesystem-oceanstor,
+# originally created by the HPC team of Vrij Universiteit Brussel (http://hpc.vub.be),
+# with support of Vrije Universiteit Brussel (http://www.vub.be),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# the Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/vub-hpc/vsc-filesystem-oceanstor
+#
+# vsc-filesystem-oceanstor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation v2.
+#
+# vsc-filesystem-oceanstor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with vsc-manage.  If not, see <http://www.gnu.org/licenses/>.
+#
+##
+"""
+Interface for Huawei Pacific OceanStor
+
+@author: Alex Domingo (Vrije Universiteit Brussel)
+"""
+
+from __future__ import print_function
+from future.utils import with_metaclass
+
+import json
+import os
+import ssl
+
+from vsc.filesystem.posix import PosixOperations
+from vsc.utils import fancylogger
+from vsc.utils.patterns import Singleton
+from vsc.utils.rest import Client, RestClient
+from vsc.utils.py2vs3 import HTTPError, HTTPSHandler, build_opener
+
+OCEANSTOR_API_URL = 'https://172.19.96.130:8088/api/v2'
+
+
+class OceanStorClient(Client):
+    """Client for OceanStor REST API"""
+
+    def __init__(self, *args, ssl_verify=True, **kwargs):
+        """Wrapper for Client.__init__() allowing to disable SSL certificate verification"""
+        super(OceanStorClient, self).__init__(*args, **kwargs)
+
+        # X-Auth-Token header
+        self.x_auth_header = None
+
+        if ssl_verify is False:
+            # Disable verification of SSL certificates
+            nossl_context = ssl._create_unverified_context()
+            nosslHandler = HTTPSHandler(context=nossl_context)
+            self.opener = build_opener(nosslHandler)
+            fancylogger.getLogger().warning("Verification of SSL certificates disabled by request!")
+
+    def request(self, *args, **kwargs):
+        """
+        Wrapper for Client.request() with HTTP error and exit code handling
+        Injects X-Auth-Token headers into teh query if present
+        """
+        # Inject X-Auth-Token into headers (args=(method, url, body, headers))
+        args = list(args)
+        if args[3] is None:
+            args[3] = {}
+        if self.x_auth_header:
+            args[3].update(self.x_auth_header)
+
+        # Execute request catching any HTTPerror
+        try:
+            status, response = super(OceanStorClient, self).request(*args, **kwargs)
+        except HTTPError as err:
+            errmsg = "OceanStor query failed with HTTP error: %s (%s)" % (err.reason, err.code)
+            fancylogger.getLogger().error(errmsg)
+            raise
+
+        # Query exit code
+        try:
+            result = response['result']
+        except AttributeError as err:
+            errmsg = "OceanStor response lacks resulting status: %s" % response
+            fancylogger.getLogger().raiseException(errmsg, exception=AttributeError)
+        else:
+            ecmsg = "OceanStor query returned exit code: %s (%s)" % (result['code'], result['description'])
+            if result['code'] != 0:
+                fancylogger.getLogger().raiseException(ecmsg, exception=RuntimeError)
+            else:
+                fancylogger.getLogger().debug(ecmsg)
+
+        return status, response
+
+    def get_x_auth_token(self, password, username=None):
+        """Request authetication token"""
+        if not username:
+            username = self.username
+
+        query_url = os.path.join('aa', 'sessions')
+        payload = {
+            'user_name': username,
+            'password': password,
+        }
+
+        status, response = self.post(query_url, body=payload)
+        print(status, response)
+        token = response['data']['x_auth_token']
+        self.x_auth_header = {'X-Auth-Token': token}
+        fancylogger.getLogger().info("OceanStor authentication switched to X-Auth-Token for this session")
+
+        return True
+
+
+class OceanStorRestClient(RestClient):
+    def __init__(self, *args, **kwargs):
+        """Create client for OceanStor with given arguments"""
+        self.client = OceanStorClient(*args, **kwargs)
+
+
+class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
+    def __init__(self, username=None, password=None):
+        super(OceanStorOperations, self).__init__()
+
+        self.log = fancylogger.getLogger()
+
+        # Open API session with user/password
+        if username is None:
+            self.log.raiseException("Missing OceanStor username", TypeError)
+        if password is None:
+            self.log.raiseException("Missing password for OceanStor user: %s" % username, TypeError)
+
+        self.session = OceanStorRestClient(OCEANSTOR_API_URL, username=username, password=password, ssl_verify=False)
+        # get a token for this session
+        self.session.client.get_x_auth_token(password)
+
+    def list_filesystems(self):
+        """
+        List all filesystems.
+        """
+        status, response = self.session.file_service.file_systems.get()
+        self.log.info("List of filesystems in OceanStor:")
+        print(json.dumps(response, indent=4))

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -109,7 +109,8 @@ class OceanStorClient(Client):
         }
 
         status, response = self.post(query_url, body=payload)
-        print(status, response)
+        fancylogger.getLogger().debug("Request for X-Auth-Token got reponse status: %s", status)
+
         token = response['data']['x_auth_token']
         self.x_auth_header = {'X-Auth-Token': token}
         fancylogger.getLogger().info("OceanStor authentication switched to X-Auth-Token for this session")
@@ -143,6 +144,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         """
         List all filesystems.
         """
-        status, response = self.session.file_service.file_systems.get()
-        self.log.info("List of filesystems in OceanStor:")
-        print(json.dumps(response, indent=4))
+        _, response = self.session.file_service.file_systems.get()
+        filesystems = [fs['name'] for fs in response['data']]
+        self.log.info("List of filesystems in OceanStor: %s", ', '.join(filesystems))
+

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -111,9 +111,14 @@ class OceanStorClient(Client):
         status, response = self.post(query_url, body=payload)
         fancylogger.getLogger().debug("Request for X-Auth-Token got reponse status: %s", status)
 
-        token = response['data']['x_auth_token']
-        self.x_auth_header = {'X-Auth-Token': token}
-        fancylogger.getLogger().info("OceanStor authentication switched to X-Auth-Token for this session")
+        try:
+            token = response['data']['x_auth_token']
+        except AttributeError as err:
+            errmsg = "X-Auth-Token not found in response from OceanStor"
+            fancylogger.getLogger().raiseException(errmsg, exception=AttributeError)
+        else:
+            self.x_auth_header = {'X-Auth-Token': token}
+            fancylogger.getLogger().info("OceanStor authentication switched to X-Auth-Token for this session")
 
         return True
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# -*- coding: latin-1 -*-
+#
+# Copyright 2022 Vrije Universiteit Brussel
+#
+# This file is part of vsc-filesystem-oceanstor,
+# originally created by the HPC team of Vrij Universiteit Brussel (http://hpc.vub.be),
+# with support of Vrije Universiteit Brussel (http://www.vub.be),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# the Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/vub-hpc/vsc-filesystem-oceanstor
+#
+# vsc-filesystem-oceanstor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation v2.
+#
+# vsc-filesystem-oceanstor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with vsc-manage.  If not, see <http://www.gnu.org/licenses/>.
+#
+##
+"""
+vsc-filesystem-oceanstor base distribution setup.py
+
+@author: Alex Domingo (Vrije Universiteit Brussel)
+"""
+
+import vsc.install.shared_setup as shared_setup
+from vsc.install.shared_setup import ad
+
+PACKAGE = {
+    'version': '0.1.0',
+    'author': [ad],
+    'maintainer': [ad],
+    'setup_requires': ['vsc-install'],
+    'install_requires': [
+        'vsc-filesystems',
+    ],
+}
+
+
+if __name__ == '__main__':
+    shared_setup.action_target(PACKAGE)


### PR DESCRIPTION
Working prototype using the REST client in `vsc-base`. I made some modifications to the base `Client` class to:
* add option to ignore SSL certificates
* handle HTTP errors and the exit code given by OceanStor
* get an authentication token and automatically inject it in any subsequent queries

At this point, interfacing with the OceanStor API is as simple as (*e.g.* to list the filesystems):
```
from vsc.filesystems.oceanstor import OceanStorOperations

OSO = OceanStorOperations(username=user, password=pwd)
OSO.session.file_service.file_systems.get()
```

Depends on https://github.com/hpcugent/vsc-base/pull/326