### PR TITLE
add list methods with filtering

### DIFF
--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -44,6 +44,9 @@ from vsc.utils.py2vs3 import HTTPError, HTTPSHandler, build_opener
 
 OCEANSTOR_API_PATH = ['api', 'v2']
 
+# REST API cannot handle white spaces between keys and values
+OCEANSTOR_JSON_SEP = (',', ':')
+
 
 class OceanStorClient(Client):
     """Client for OceanStor REST API"""
@@ -153,9 +156,6 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         self.filesystems = None
         self.filesets = None
 
-        # OceanStor API JSON formatting
-        # REST API cannot handle white spaces between keys and values
-        self.json_sep = (',', ':')
 
         # OceanStor API URL
         self.url = os.path.join(url, *OCEANSTOR_API_PATH)
@@ -171,6 +171,11 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         # Get token for this session
         self.session.client.get_x_auth_token(password)
+
+    @staticmethod
+    def json_separators(): 
+        """JSON formatting for OceanStor API"""
+        return OCEANSTOR_JSON_SEP
 
     def list_storage_pools(self, update=False):
         """
@@ -276,7 +281,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         sp_ids = self.select_storage_pools(device, byid=True)
         filter_sp_ids = [{'storage_pool_id': str(sp_id)} for sp_id in sp_ids]
-        filter_sp_ids_json = json.dumps(filter_sp_ids, separators=self.json_sep)
+        filter_sp_ids_json = json.dumps(filter_sp_ids, separators=self.json_separators())
         self.log.debug("Filtering filesystems in storage pools with IDs: %s", ', '.join(str(i) for i in sp_ids))
 
         if not update and self.filesystems:

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -97,7 +97,7 @@ class OceanStorClient(Client):
             # Some queries generate a response with an int result
             # e.g. GET 'data_service/storagepool'
             exit_code = result
-            ec_msg = "%s" % result
+            ec_msg = str(exit_code)
         else:
             ec_msg_desc = result['description']
             if 'suggestion' in result:

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -77,8 +77,6 @@ class OceanStorClient(Client):
         # Execute request catching any HTTPerror
         try:
             status, response = super(OceanStorClient, self).request(*args, **kwargs)
-            print(args[0])
-            print(json.dumps(response, indent=4))
         except HTTPError as err:
             errmsg = "OceanStor query failed with HTTP error: %s (%s)" % (err.reason, err.code)
             fancylogger.getLogger().error(errmsg)
@@ -157,7 +155,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         # OceanStor API JSON formatting
         # REST API cannot handle white spaces between keys and values
-        self.json_sep = (',', ':') 
+        self.json_sep = (',', ':')
 
         # OceanStor API URL
         self.url = os.path.join(url, *OCEANSTOR_API_PATH)
@@ -358,7 +356,6 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         filter_fs = self.select_filesystems(filesystemnames, devices)
         self.log.debug("Seeking dtree filesets in filesystems: %s", ', '.join(filter_fs))
-        print("Seeking dtree filesets in filesystems: %s" % ', '.join(filter_fs))
 
         # Filter by fileset name
         if filesetnames is not None:
@@ -366,7 +363,6 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                 filesetnames = [filesetnames]
 
             self.log.debug("Filtering dtree filesets by name: %s", ', '.join(filesetnames))
-            print("Filtering dtree filesets by name: %s" % ', '.join(filesetnames))
 
         if not update and self.filesets:
             # Use cached dtree fileset data and filter by filesystem name
@@ -400,6 +396,5 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         for fs in dtree_filesets:
             dt_names = [dtree_filesets[fs][dt]['name'] for dt in dtree_filesets[fs]]
             self.log.debug(dbg_prefix + "Dtree filesets in OceanStor filesystem '%s': %s", fs, ', '.join(dt_names))
-            print(dbg_prefix + "Dtree filesets in OceanStor filesystem '%s': %s" % (fs, ', '.join(dt_names)))
 
         return dtree_filesets

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -204,18 +204,19 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         # Request storage pools
         _, response = self.session.data_service.storagepool.get()
-        storage_pools = [sp['storagePoolName'] for sp in response['storagePools']]
-        self.log.debug("Storage pools in OceanStor: %s", ', '.join(storage_pools))
 
-        res = dict()
+        # Organize in a dict by storage pool name
+        storage_pools = dict()
         for sp in response['storagePools']:
-            res.update({sp['storagePoolName']: sp})
+            storage_pools.update({sp['storagePoolName']: sp})
 
-        if len(res) == 0:
+        if len(storage_pools) == 0:
             self.log.raiseException("No storage pools found in OceanStor", RuntimeError)
+        else:
+            self.log.debug("Storage pools in OceanStor: %s", ', '.join(storage_pools))
 
-        self.storagepools = res
-        return res
+        self.storagepools = storage_pools
+        return storage_pools
 
     def storage_pool_names_to_ids(self, sp_names):
         """

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -229,7 +229,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         """
         Return list of existing storage pools with the provided storage pool names
 
-        @type sp_names: list of names (if string: 1 device; if None or all: all known devices)
+        @type sp_names: list of names (if string: 1 device)
         """
         storage_pools = self.list_storage_pools()
 
@@ -255,6 +255,8 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
     def list_filesystems(self, device=None, update=False):
         """
         List all filesystems
+
+        @type device: list of names (if string: 1 device, if None or all: all known devices)
 
         Set self.filesystems to a convenient dict structure of the returned dict
         where the key is the filesystem name, the value is a dict with keys:
@@ -305,7 +307,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         Return list of existing filesytem with the provided filesystem names
         Restrict list to filesystems found in given storage pools names
 
-        @type filesystemnames: list of filesystem names (if string: 1 filesystem; if None: all known filesystems)
+        @type filesystemnames: list of filesystem names (if string: 1 filesystem)
         @type devices: list of storage pools names (if string: 1 storage pool; if None: all known storage pools)
         @type byid: boolean (if True: return list of filesystem IDs)
         """

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -155,6 +155,10 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         self.filesystems = None
         self.filesets = None
 
+        # OceanStor API JSON formatting
+        # REST API cannot handle white spaces between keys and values
+        self.json_sep = (',', ':') 
+
         # OceanStor API URL
         self.url = os.path.join(url, *OCEANSTOR_API_PATH)
         self.log.info("URL of OceanStor server: %s", self.url)
@@ -269,7 +273,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         # Filter by requested devices (storage pools in OceanStor)
         sp_ids = self.storage_pool_names_to_ids(device)
         filter_sp_ids = [{'storage_pool_id': sp_id} for sp_id in sp_ids]
-        filter_sp_ids_json = json.dumps(filter_sp_ids, separators=(',', ':'))
+        filter_sp_ids_json = json.dumps(filter_sp_ids, separators=self.json_sep)
         self.log.debug("Filtering filesystems in storage pools with IDs: %s", ', '.join(sp_ids))
 
         if not update and self.filesystems:

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ import vsc.install.shared_setup as shared_setup
 from vsc.install.shared_setup import ad
 
 PACKAGE = {
-    'version': '0.1.0',
+    'version': '0.2.0',
     'author': [ad],
     'maintainer': [ad],
     'setup_requires': ['vsc-install'],


### PR DESCRIPTION
New methods in `OceanStorOperations`:
* `list_storage_pools`: list all storage pools available
* `list_filesystems`: list all filesystems. Can filter by storage pool (*aka* device in GPFS terms)
* `list_filesets`: list all dtree filesets. Can filter by storage pool (*aka* device in GPFS terms), by filesystem and name of fileset.

These methods are analogous in construction to their counterparts in `vsc.filesystem.gpfs.GpfsOperations`:
* Data is requested to the *filesystem* once and stored in class attributes (*e.g.* `self.filesystems` and `self.filesets`)
* Cached data can be updated by calling these methods with `update = True`
* The filtering capabilities are either the same or expanded

Bugfixes:
* Handle request responses where the result only contains an integer with the exit code