### PR TITLE
add support for making filesets

### DIFF
--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -36,7 +36,7 @@ import json
 import os
 import ssl
 
-from vsc.filesystem.posix import PosixOperations
+from vsc.filesystem.posix import PosixOperations, PosixOperationError
 from vsc.utils import fancylogger
 from vsc.utils.patterns import Singleton
 from vsc.utils.rest import Client, RestClient
@@ -145,6 +145,10 @@ class OceanStorRestClient(RestClient):
         self.client = OceanStorClient(*args, **kwargs)
 
 
+class OceanStorOperationError(PosixOperationError):
+    pass
+
+
 class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
     def __init__(self, url, username=None, password=None):
         """Initialize REST client and request authentication token"""
@@ -218,7 +222,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             storage_pools.update({sp['storagePoolName']: sp})
 
         if len(storage_pools) == 0:
-            self.log.raiseException("No storage pools found in OceanStor", RuntimeError)
+            self.log.raiseException("No storage pools found in OceanStor", OceanStorOperationError)
         else:
             self.log.debug("Storage pools in OceanStor: %s", ', '.join(storage_pools))
 

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -152,9 +152,9 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         self.log = fancylogger.getLogger()
 
-        self.storagepools = None
-        self.filesystems = None
-        self.filesets = None
+        self.oceanstor_storagepools = None
+        self.oceanstor_filesystems = None
+        self.oceanstor_filesets = None
 
 
         # OceanStor API URL
@@ -181,7 +181,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         """
         List all storage pools (equivalent to devices in GPFS)
 
-        Set self.storagepools to a convenient dict structure of the returned dict
+        Set self.oceanstor_storagepools to a convenient dict structure of the returned dict
         where the key is the storagePoolName, the value is a dict with keys:
         - storagePoolId
         - storagePoolName
@@ -206,8 +206,8 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         - encryptType
         - supportEncryptForMainStorageMedia
         """
-        if not update and self.storagepools:
-            return self.storagepools
+        if not update and self.oceanstor_storagepools:
+            return self.oceanstor_storagepools
 
         # Request storage pools
         _, response = self.session.data_service.storagepool.get()
@@ -222,7 +222,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         else:
             self.log.debug("Storage pools in OceanStor: %s", ', '.join(storage_pools))
 
-        self.storagepools = storage_pools
+        self.oceanstor_storagepools = storage_pools
         return storage_pools
 
     def select_storage_pools(self, sp_names, byid=False):
@@ -258,7 +258,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         @type device: list of names (if string: 1 device, if None or all: all known devices)
 
-        Set self.filesystems to a convenient dict structure of the returned dict
+        Set self.oceanstor_filesystems to a convenient dict structure of the returned dict
         where the key is the filesystem name, the value is a dict with keys:
         - atime_update_mode
         - dentry_table_type
@@ -286,9 +286,9 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         filter_sp_ids_json = json.dumps(filter_sp_ids, separators=self.json_separators())
         self.log.debug("Filtering filesystems in storage pools with IDs: %s", ', '.join(str(i) for i in sp_ids))
 
-        if not update and self.filesystems:
+        if not update and self.oceanstor_filesystems:
             # Use cached filesystem data
-            filesystems = {fs['name']: fs for fs in self.filesystems.values() if fs['storage_pool_id'] in sp_ids}
+            filesystems = {fs['name']: fs for fs in self.oceanstor_filesystems.values() if fs['storage_pool_id'] in sp_ids}
             dbg_prefix = "(cached) "
         else:
             # Request filesystem data
@@ -296,7 +296,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             filesystems = {fs['name']: fs for fs in response['data']}
             dbg_prefix = ""
 
-            self.filesystems = filesystems
+            self.oceanstor_filesystems = filesystems
 
         self.log.debug(dbg_prefix + "Filesystems in OceanStor: %s", ", ".join(filesystems))
 
@@ -344,7 +344,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         @type filesystemnames: list of filesystem names (if string: 1 filesystem; if None: all known filesystems)
         @type filesetnames: list of fileset names (if string: 1 fileset)
 
-        Set self.filesets as dict with
+        Set self.oceanstor_filesets as dict with
         : keys per parent filesystemName and value is dict with
         :: keys per dtree fileset ID and value is dict with
         ::: keys returned by OceanStor:
@@ -371,10 +371,10 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
             self.log.debug("Filtering dtree filesets by name: %s", ', '.join(filesetnames))
 
-        if not update and self.filesets:
+        if not update and self.oceanstor_filesets:
             # Use cached dtree fileset data and filter by filesystem name
             dbg_prefix = "(cached) "
-            dtree_filesets = {fs: self.filesets[fs] for fs in filter_fs}
+            dtree_filesets = {fs: self.oceanstor_filesets[fs] for fs in filter_fs}
         else:
             # Request dtree filesets
             dbg_prefix = ""
@@ -387,7 +387,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                 dtree_filesets[fs_name] = fs_dtree
 
             # Store all dtree filesets in the selected filesystems
-            self.filesets = dtree_filesets
+            self.oceanstor_filesets = dtree_filesets
 
         if filesetnames:
             # Filter by name of fileset

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -113,12 +113,10 @@ class OceanStorClient(Client):
 
         return status, response
 
-    def get_x_auth_token(self, password, username=None):
+    def get_x_auth_token(self, username, password):
         """Request authetication token"""
-        if not username:
-            username = self.username
-
         query_url = os.path.join('aa', 'sessions')
+
         payload = {
             'user_name': username,
             'password': password,
@@ -133,6 +131,7 @@ class OceanStorClient(Client):
             errmsg = "X-Auth-Token not found in response from OceanStor"
             fancylogger.getLogger().raiseException(errmsg, exception=AttributeError)
         else:
+            self.username = username
             self.x_auth_header = {'X-Auth-Token': token}
             fancylogger.getLogger().info("OceanStor authentication switched to X-Auth-Token for this session")
 
@@ -171,10 +170,10 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         if password is None:
             self.log.raiseException("Missing password for OceanStor user: %s" % username, TypeError)
 
-        self.session = OceanStorRestClient(self.url, username=username, password=password, ssl_verify=False)
-
-        # Get token for this session
-        self.session.client.get_x_auth_token(password)
+        # Initialize REST client without user/password
+        self.session = OceanStorRestClient(self.url, ssl_verify=False)
+        # Get token for this session with user/password
+        self.session.client.get_x_auth_token(username, password)
 
     @staticmethod
     def json_separators(): 

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -149,7 +149,7 @@ class OceanStorOperationError(PosixOperationError):
 
 
 class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
-    def __init__(self, url, username=None, password=None):
+    def __init__(self, url, username, password):
         """Initialize REST client and request authentication token"""
         super(OceanStorOperations, self).__init__()
 
@@ -163,12 +163,6 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         # OceanStor API URL
         self.url = os.path.join(url, *OCEANSTOR_API_PATH)
         self.log.info("URL of OceanStor server: %s", self.url)
-
-        # Open API session with user/password
-        if username is None:
-            self.log.raiseException("Missing OceanStor username", TypeError)
-        if password is None:
-            self.log.raiseException("Missing password for OceanStor user: %s" % username, TypeError)
 
         # Initialize REST client without user/password
         self.session = OceanStorRestClient(self.url, ssl_verify=False)

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -160,7 +160,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         """
         super(OceanStorOperations, self).__init__()
 
-        self.log = fancylogger.getLogger()
+        self.supportedfilesystems = ['nfs']
 
         self.oceanstor_storagepools = None
         self.oceanstor_filesystems = None

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -81,6 +81,8 @@ class OceanStorClient(Client):
         # Execute request catching any HTTPerror
         try:
             status, response = super(OceanStorClient, self).request(*args, **kwargs)
+            print(args[0])
+            print(json.dumps(response, indent=4))
         except HTTPError as err:
             errmsg = "OceanStor query failed with HTTP error: %s (%s)" % (err.reason, err.code)
             fancylogger.getLogger().error(errmsg)
@@ -522,8 +524,8 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         @type fileset_name: string with the name of the new fileset
         @type filesystem_name: string with the name of an existing filesystem
-        @type filesystem_name: string with the path of parent directory of new fileset
-                               (path relative to root of filesystem)
+        @type parent_dir: string with path of parent directory of new fileset
+                          (path relative to root of filesystem)
         """
         self.list_filesets()  # make sure fileset data is present (but do not update)
 

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -149,8 +149,15 @@ class OceanStorOperationError(PosixOperationError):
 
 
 class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
-    def __init__(self, url, username, password):
-        """Initialize REST client and request authentication token"""
+    def __init__(self, api_url, nfs_ips, username, password):
+        """
+        Initialize REST client and request authentication token
+
+        @type api_url: string with URL of REST API, only scheme and FQDM of server is needed
+        @type nfs_ips: list of IPs or FQDM of the NFS servers (if string: 1 IP)
+        @type username: string with username for the REST API
+        @type password: string with plain password for the REST API
+        """
         super(OceanStorOperations, self).__init__()
 
         self.log = fancylogger.getLogger()
@@ -159,13 +166,17 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         self.oceanstor_filesystems = None
         self.oceanstor_filesets = None
 
+        if not isinstance(nfs_ips, list):
+            self.nfs_ips = [nfs_ips]
+        else:
+            self.nfs_ips = nfs_ips
 
         # OceanStor API URL
-        self.url = os.path.join(url, *OCEANSTOR_API_PATH)
-        self.log.info("URL of OceanStor server: %s", self.url)
+        self.api_url = os.path.join(api_url, *OCEANSTOR_API_PATH)
+        self.log.info("URL of OceanStor REST API server: %s", self.api_url)
 
         # Initialize REST client without user/password
-        self.session = OceanStorRestClient(self.url, ssl_verify=False)
+        self.session = OceanStorRestClient(self.api_url, ssl_verify=False)
         # Get token for this session with user/password
         self.session.client.get_x_auth_token(username, password)
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ import vsc.install.shared_setup as shared_setup
 from vsc.install.shared_setup import ad
 
 PACKAGE = {
-    'version': '0.2.0',
+    'version': '0.3.0',
     'author': [ad],
     'maintainer': [ad],
     'setup_requires': ['vsc-install'],


### PR DESCRIPTION
Changelog:
* add `_local_filesystems()` to identify NFs mounts in the local system that originate in OceanStor
* add `make_fileset()` to create new filesets in OceanStor (in a filesystem already mounted with NFS)
* initialize `OceanStorRestClient` without user or password and make user/password mandatory in `get_x_auth_token()`
* add `oceanstor` prefix to the main data objects in `oceanStorOperations`
* define `OceanStorOperationError`

The following calls are equivalent:
* `OceanStorOperations.make_fileset('/mnt/new_dtree_01')`
* `OceanStorOperations.make_fileset('/mnt', fileset_name='new_dtree_01')`