### PR TITLE
add support for retrieving NFS information from OceanStor

### DIFF
--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -654,11 +654,10 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         """
         Create a new fileset in a NFS mounted filesystem from OceanStor
 
-        - The name of the dtree fileset and the folder where it is mounted always share the same name.
+        - All filesets in a common filesystem must have unique names (enforced by API)
+        - The name of the dtree fileset and the folder where it is mounted always share the same name
         - Dtree filesets cannot be nested (parent_fileset_name is ignored)
-        - Dtree filesets can be created at specific path inside the NFS mount (i.e. filesystem),
-          but this information cannot be retrieved back from the OceanStor API (list_filesets()).
-          Therefore, all filesets in a common filesystem must have unique names.
+        - Dtree filesets can be created at specific path inside the NFS mount (i.e. filesystem)
 
         @type new_fileset_path: string with the full path in the local system of the new fileset
         @type fileset_name: string with the name of the new fileset
@@ -724,11 +723,9 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         """
         Create new dtree fileset in given filesystem of OceanStor
 
+        - All filesets in a common filesystem must have unique names (enforced by API)
         - Dtree filesets cannot be nested
-        - Dtree filesets can be created at specific path inside the filesystem,
-          but this information cannot be retrieved back from the OceanStor API
-          (list_filesets()). Therefore, all filesets in a common filesystem must
-          have unique names.
+        - Dtree filesets can be created at specific paths inside the filesystem
 
         @type fileset_name: string with the name of the new fileset
         @type filesystem_name: string with the name of an existing filesystem

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -390,6 +390,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         - id
         - name
         - owner
+        - parent_dir
         - security_style
         - unix_mode
         """

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -416,6 +416,12 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                 # query dtrees in this filesystem
                 _, response = self.session.file_service.dtrees.get(file_system_name=fs_name)
                 fs_dtree = {dt['id']: dt for dt in response['data']}
+                # query parent directory of each individual fileset by ID (fsId@dtreeId)
+                for dt_id in fs_dtree:
+                    dtree_api_path = os.path.join('file_service', 'dtrees', dt_id)
+                    _, dt_response = self.session.get(url=dtree_api_path)
+                    fs_dtree[dt_id]['parent_dir'] = dt_response['data']['parent_dir']
+            
                 dtree_filesets[fs_name] = fs_dtree
 
             dt_names = [dt['name'] for dt in dtree_filesets[fs_name].values()]

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -757,6 +757,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             self.log.debug("Validated name of new dtree fileset: %s", fileset_name)
 
         # Ensure absolute path for parent directory
+        # TODO: create parent directory if it does not exist
         if not os.path.isabs(parent_dir):
             parent_dir = '/' + parent_dir
 

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -637,7 +637,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                         dbgmsg = "Local NFS mount '%s' is served by OceanStor and shares object ID: %s"
                         self.log.debug(dbgmsg, mount_point, oceanstor_tag)
                     else:
-                        errmsg = "NFS mount '%s' served from OceanStor '%s' shares unkown path '%s'"
+                        errmsg = "NFS mount '%s' served from OceanStor '%s' shares unknown path '%s'"
                         errmsg = errmsg % (mount_point, str(server_ip), share_path)
                         self.log.raiseException(errmsg, OceanStorOperationError)
 

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -81,8 +81,6 @@ class OceanStorClient(Client):
         # Execute request catching any HTTPerror
         try:
             status, response = super(OceanStorClient, self).request(*args, **kwargs)
-            print(args[0])
-            print(json.dumps(response, indent=4))
         except HTTPError as err:
             errmsg = "OceanStor query failed with HTTP error: %s (%s)" % (err.reason, err.code)
             fancylogger.getLogger().error(errmsg)
@@ -192,8 +190,9 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         """
         List all storage pools (equivalent to devices in GPFS)
 
-        Set self.oceanstor_storagepools to a convenient dict structure of the returned dict
-        where the key is the storagePoolName, the value is a dict with keys:
+        Set self.oceanstor_storagepools as dict with
+        : keys per storagePoolName and value is dict with
+        :: keys returned by OceanStor:
         - storagePoolId
         - storagePoolName
         - totalCapacity
@@ -269,8 +268,9 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         @type device: list of names (if string: 1 device, if None or all: all known devices)
 
-        Set self.oceanstor_filesystems to a convenient dict structure of the returned dict
-        where the key is the filesystem name, the value is a dict with keys:
+        Set self.oceanstor_filesystems as dict with
+        : keys per filesystemName and value is dict with
+        :: keys returned by OceanStor:
         - atime_update_mode
         - dentry_table_type
         - dir_split_bitwidth
@@ -374,7 +374,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             filesystems = self.list_filesystems(update=update)
             filesystemnames = list(filesystems.keys())
 
-        filter_fs = self.select_filesystems(filesystemnames, devices)
+        filter_fs = self.select_filesystems(filesystemnames, devices=devices)
         self.log.debug("Seeking dtree filesets in filesystems: %s", ', '.join(filter_fs))
 
         # Filter by fileset name

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -168,13 +168,13 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         self.supportedfilesystems = ['nfs']
 
-        self.oceanstor_storagepools = None
-        self.oceanstor_filesystems = None
-        self.oceanstor_filesets = None
+        self.oceanstor_storagepools = dict()
+        self.oceanstor_filesystems = dict()
+        self.oceanstor_filesets = dict()
 
-        self.oceanstor_nfsshares = None
-        self.oceanstor_nfsclients = None
-        self.oceanstor_nfsservers = None
+        self.oceanstor_nfsshares = dict()
+        self.oceanstor_nfsclients = dict()
+        self.oceanstor_nfsservers = dict()
 
         self.account = account
 
@@ -393,8 +393,6 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         - security_style
         - unix_mode
         """
-        if self.oceanstor_filesets is None:
-            self.oceanstor_filesets = dict()
 
         # Filter by filesystem name (in target storage pools)
         if filesystemnames is None:
@@ -467,8 +465,6 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         - id
         - share_path
         """
-        if self.oceanstor_nfsshares is None:
-            self.oceanstor_nfsshares = dict()
 
         # Filter by filesystem name
         if filesystemnames is None:
@@ -530,8 +526,6 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         - sync
         - type
         """
-        if self.oceanstor_nfsclients is None:
-            self.oceanstor_nfsclients = dict()
 
         # NFS shares in given filesystems
         nfs_shares = self.list_nfs_shares(filesystemnames=filesystemnames, update=update)

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -334,7 +334,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         """
         if not isinstance(filesystemnames, list):
             filesystemnames = [filesystemnames]
-        
+
         target_filesystems = [str(fs) for fs in filesystemnames]
 
         # Filter by storage pools
@@ -348,7 +348,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                 errmsg = "Malformed list of filesystem IDs: %s"
                 self.log.raiseException(errmsg % ', '.join([str(fs_id) for fs_id in target_filesystems]), ValueError)
             else:
-                # Convert known IDs to names 
+                # Convert known IDs to names
                 for n, fs_id in enumerate(target_filesystems_id):
                     fs_name = [fs for fs in filesystems if filesystems[fs]['id'] == fs_id]
                     if fs_name:
@@ -421,7 +421,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                     dtree_api_path = os.path.join('file_service', 'dtrees', dt_id)
                     _, dt_response = self.session.get(url=dtree_api_path)
                     fs_dtree[dt_id]['parent_dir'] = dt_response['data']['parent_dir']
-            
+
                 dtree_filesets[fs_name] = fs_dtree
 
             dt_names = [dt['name'] for dt in dtree_filesets[fs_name].values()]
@@ -596,7 +596,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             errmsg = "Received malformed server IPs from OceanStor: %s" % comma_sep_ips
             self.log.raiseException(errmsg, OceanStorOperationError)
         else:
-            self.log.debug("NFS servers in OceanStor: %s", comma_sep_ips) 
+            self.log.debug("NFS servers in OceanStor: %s", comma_sep_ips)
 
         self.oceanstor_nfsservers = nfs_servers
         return nfs_servers
@@ -618,7 +618,8 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         oceanstor_shares = self.list_nfs_shares()
         oceanstor_share_paths = {
             os.path.normpath(nfs_share[ns]['share_path']): nfs_share[ns]['dtree_id']
-            for nfs_share in oceanstor_shares.values() for ns in nfs_share
+            for nfs_share in oceanstor_shares.values()
+            for ns in nfs_share
         }
 
         for fs in self.localfilesystems:
@@ -639,7 +640,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                     if share_path in oceanstor_share_paths:
                         oceanstor_tag = oceanstor_share_paths[share_path]
                         dbgmsg = "Local NFS mount '%s' is served by OceanStor and shares object ID: %s"
-                        self.log.debug(dbgmsg, mount_point, oceanstor_tag) 
+                        self.log.debug(dbgmsg, mount_point, oceanstor_tag)
                     else:
                         errmsg = "NFS mount '%s' served from OceanStor '%s' shares unkown path '%s'"
                         errmsg = errmsg % (mount_point, str(server_ip), share_path)

--- a/setup.py
+++ b/setup.py
@@ -34,14 +34,20 @@ vsc-filesystem-oceanstor base distribution setup.py
 import vsc.install.shared_setup as shared_setup
 from vsc.install.shared_setup import ad
 
+install_requires = [
+    'vsc-filesystems',
+]
+
+if sys.version_info < (3, 3):
+    # Backport of the 3.3+ ipaddress module
+    install_requires.append('ipaddress')
+
 PACKAGE = {
     'version': '0.3.0',
     'author': [ad],
     'maintainer': [ad],
     'setup_requires': ['vsc-install'],
-    'install_requires': [
-        'vsc-filesystems',
-    ],
+    'install_requires': install_requires,
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ if sys.version_info < (3, 3):
     install_requires.append('ipaddress')
 
 PACKAGE = {
-    'version': '0.3.0',
+    'version': '0.4.0',
     'author': [ad],
     'maintainer': [ad],
     'setup_requires': ['vsc-install'],


### PR DESCRIPTION
Major changes:
* Fixed list of IPs of NFS servers removed. Local NFS mounts continue to be identified by `_local_filesystems()` by the IP of the NFS server and the path of the NFS share, but now that data is compared to that reported by OceanStor API.
* New methods to query OceanStor about NFS mounts:
    * NFS shares: `list_nfs_shares()`
    * NFS clients: `list_nfs_clients()` (not used anywhere though)
    * NFS servers: `list_nfs_servers()`
* One advantge of this new approach, is that now we know in advance if a NFS mount contains a filesystem or a dtree. Hence `make_fileset()` received an additional check to verify that the new fileset does not go into another fileset.

Minor changes:
* Use of cached data has been improved, `list_` methods called without `update` will return as much data as is available locally and query the missing bits to the API
* Method `list_fileset()` now also adds the `parent_dir ` of each dtree
* Method `select_filesystems()` has been improved to also allow selecting filesystems by ID with `byid` option. It will always return a dict of names and IDs of selected filesystems.
* I finally understood how `filter` works in GET requests: we can add multiple keywords to the filter but not multiple values of the same keyword. This means that `list_filesystems` has been changed to loop over each `storage_pool_id` instead of adding all at once to `filter`.
* add dependency on `ipaddres` for Python < 3.3 (used to handle NFS server IPs)