### PR TITLE
add support to list and set quotas

### DIFF
--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -778,7 +778,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
 
     def make_fileset(self, new_fileset_path, fileset_name=None, parent_fileset_name=None, afm=None,
-                     inodes_max=1048576, inodes_prealloc=None):
+                     inodes_max=1048576, inodes_prealloc=None, nfs_cache=False):
         """
         Create a new fileset in a NFS mounted filesystem from OceanStor
 
@@ -791,6 +791,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         @type fileset_name: string with the name of the new fileset
                             (if not None, fileset_name is appended to new_fileset_path)
         @type inodes_max: int with initial limit of inodes for this fileset
+        @type nfs_cache: bool enabling wait time to deal with NFS lookup cache
         """
         # Unsupported features
         del afm
@@ -836,8 +837,9 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         self.make_fileset_api(fileset_name, ostor_fs_name, parent_dir=ostor_parentdir)
 
-        # wait for NFS lookup cache to expire to be able to access new fileset
-        time.sleep(NFS_LOOKUP_CACHE_TIME)
+        if nfs_cache:
+            # wait for NFS lookup cache to expire to be able to access new fileset
+            time.sleep(NFS_LOOKUP_CACHE_TIME)
 
         # Set initial quotas: 1MB for blocks soft limit and inodes_max for inodes soft limit
         block_soft = 1048576  # bytes

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -112,12 +112,6 @@ class OceanStorClient(Client):
             self.opener = build_opener(nosslHandler)
             fancylogger.getLogger().warning("Verification of SSL certificates disabled by request!")
 
-    def _get(self, *args, **kwargs):
-        """
-        Private GET method copycat of Client.get()
-        """
-        return super(OceanStorClient, self).get(*args, **kwargs)
-
     def get(self, url, pagination=None, headers=None, **params):
         """
         HTTP GET request of all pages in the given url with given headers and parameters
@@ -129,7 +123,7 @@ class OceanStorClient(Client):
         """
         # GET query without pagination
         if pagination is None:
-            return self._get(url, headers=headers, **params)
+            return super(OceanStorClient, self).get(url, headers=headers, **params)
 
         # GET query with pagination
         query_range = {
@@ -143,7 +137,7 @@ class OceanStorClient(Client):
         while pagination > 0:
             # loop over pages
             params['range'] = json.dumps(query_range, separators=OCEANSTOR_JSON_SEP)
-            item_status, item_response = self._get(url, headers=headers, **params)
+            item_status, item_response = super(OceanStorClient, self).get(url, headers=headers, **params)
 
             # append page
             status = item_status

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -187,11 +187,6 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         # Get token for this session with user/password
         self.session.client.get_x_auth_token(username, password)
 
-    @staticmethod
-    def json_separators():
-        """JSON formatting for OceanStor API"""
-        return OCEANSTOR_JSON_SEP
-
     def list_storage_pools(self, update=False):
         """
         List all storage pools (equivalent to devices in GPFS)
@@ -313,7 +308,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             filesystems = dict()
             for sp_id in filter_sp:
                 filter_json = [{'storage_pool_id': str(sp_id)}]
-                filter_json = json.dumps(filter_json, separators=self.json_separators())
+                filter_json = json.dumps(filter_json, separators=OCEANSTOR_JSON_SEP)
                 _, response = self.session.file_service.file_systems.get(filter=filter_json)
                 filesystems.update({fs['name']: fs for fs in response['data']})
 
@@ -485,7 +480,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                 # Request NFS shares
                 dbg_prefix = ""
                 filter_json = [{'fs_id': str(fs_id)}]
-                filter_json = json.dumps(filter_json, separators=self.json_separators())
+                filter_json = json.dumps(filter_json, separators=OCEANSTOR_JSON_SEP)
                 query_params = {
                     'account_name': self.account,
                     'filter': filter_json,
@@ -552,7 +547,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                 # Request NFS clients for this share
                 dbg_prefix = ""
                 filter_json = [{'share_id': str(ns_id)}]
-                filter_json = json.dumps(filter_json, separators=self.json_separators())
+                filter_json = json.dumps(filter_json, separators=OCEANSTOR_JSON_SEP)
                 query_params = {
                     'account_name': self.account,
                     'filter': filter_json,

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ if sys.version_info < (3, 3):
     install_requires.append('ipaddress')
 
 PACKAGE = {
-    'version': '0.4.0',
+    'version': '0.5.0',
     'author': [ad],
     'maintainer': [ad],
     'setup_requires': ['vsc-install'],

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,8 @@ vsc-filesystem-oceanstor base distribution setup.py
 @author: Alex Domingo (Vrije Universiteit Brussel)
 """
 
+import sys
+
 import vsc.install.shared_setup as shared_setup
 from vsc.install.shared_setup import ad
 


### PR DESCRIPTION
Major changes:
* new methods to set user/group/fileset quotas
* new methods to set grace periods of user/group/fileset quotas
* new method `list_quota` to retrieve all information from all quotas in OceanStor
* new method `_get_quota` retrieves all quota information from a local path
* new method `_identify_local_path` to get OceanStor attributes from a local path (used to make new filesets and set quotas)

Minor changes:
* enhance `OceanStorClient,get()` to automatically handle paginated requests
* resolve hostname of NFS servers
* new filesets are now created with an initial default quota

This version has been tested in vacuum with the `test` filesystem. So far everything is working as expected:
* creation/modification of quotas in filesystems
* creation/modification of quotas in filesets
* creation of new filesets with an initial quota
* modification of grace times

Next step is to use it from `vsc-administration`. All pieces are already in place.