### PR TITLE
Final integration with vsc-administration

### DIFF
--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -448,6 +448,24 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         return fs_select
 
+    def get_filesystem_info(self, filesystem):
+        """
+        Get all the relevant information for a given OceanStor filesystem.
+
+        @type filesystem: string representing the name of the filesystem in OceanStor
+
+        @returns: dictionary with the OceanStor information
+
+        @raise OceanStorOperationError: if there is no filesystem with the given name
+        """
+        self.list_filesystems()
+        try:
+            return self.oceanstor_filesystems[filesystem]
+        except KeyError:
+            errmsg = "OceanStor has no information for filesystem %s" % (filesystem)
+            self.log.raiseException(errmsg, OceanStorOperationError)
+            return None
+
     def list_filesets(self, devices=None, filesystemnames=None, filesetnames=None, update=False):
         """
         Get all dtree filesets in given devices and given filesystems

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -541,6 +541,30 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         return dtree_filesets
 
+    def get_fileset_info(self, filesystem_name, fileset_name):
+        """
+        Get all the relevant information for a given fileset.
+
+        @type filesystem_name: string representing a OceanStor filesystem
+        @type fileset_name: string representing a OceanStor fileset name (not the ID)
+
+        @returns: dictionary with the fileset information or None if the fileset cannot be found
+
+        @raise OceanStorOperationError: if there is no filesystem with the given name
+        """
+        self.list_filesets(filesystemnames=filesystem_name)
+        try:
+            filesystem_fsets = self.oceanstor_filesets[filesystem_name]
+        except KeyError:
+            errmsg = "OceanStor has no fileset information for filesystem %s" % filesystem_name
+            self.log.raiseException(errmsg, GpfsOperationError)
+
+        for fset in filesystem_fsets.values():
+            if fset['name'] == fileset_name:
+                return fset
+
+        return None
+
     def list_nfs_shares(self, filesystemnames=None, update=False):
         """
         Get all NFS shares in given filesystems

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -1135,8 +1135,9 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                 soft = user_dtree_quota['space_soft_quota']
                 self.log.debug("Updated user default soft quota in '%s' to 100%% of dtree quota: %s bytes", obj, soft)
             else:
-                errmsg = "cannot set user default quota in a dtree without fileset quota: %s" % obj
-                self.log.raiseException(errmsg, OceanStorOperationError)
+                # new VO with fileset quota missing, create it with user limits
+                self.log.debug("Creating fileset quota in '%s' with soft limit: %s bytes", obj, soft)
+                self.set_fileset_quota(soft, obj, hard=hard, inode_soft=inode_soft, inode_hard=inode_hard)
                 
         quota_limits = {'soft': soft, 'hard': hard, 'inode_soft': inode_soft, 'inode_hard': inode_hard}
         self._set_quota(who=user, obj=obj, typ='user', **quota_limits)

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -235,11 +235,11 @@ class OceanStorOperationError(PosixOperationError):
 
 
 class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
-    def __init__(self, api_url, account, username, password):
+    def __init__(self, url, account, username, password):
         """
         Initialize REST client and request authentication token
 
-        @type api_url: string with URL of REST API, only scheme and FQDM of server is needed
+        @type url: string with URL of REST API, only scheme and FQDM of server is needed
         @type account: string with name of account in OceanStor
         @type username: string with username for the REST API
         @type password: string with plain password for the REST API
@@ -260,7 +260,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         self.account = account
 
         # OceanStor API URL
-        self.api_url = os.path.join(api_url, *OCEANSTOR_API_PATH)
+        self.api_url = os.path.join(url, *OCEANSTOR_API_PATH)
         self.log.info("URL of OceanStor REST API server: %s", self.api_url)
 
         # Initialize REST client without user/password

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -876,10 +876,6 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             # wait for NFS lookup cache to expire to be able to access new fileset
             time.sleep(NFS_LOOKUP_CACHE_TIME)
 
-        # Set initial quotas: 1MB for blocks soft limit and inodes_max for inodes soft limit
-        block_soft = 1048576  # bytes
-        self.set_fileset_quota(block_soft, dtree_fullpath, inode_soft=inodes_max)
-
         # Set a default user quota: 1MB for blocks soft limit and inodes_max for inodes soft limit
         # TODO: remove once OceanStor supports setting user quotas on non-empty filesets
         block_soft = 1048576  # bytes

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -1116,6 +1116,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         """
         # TODO: remove (1) and (2) once OceanStor supports setting user quotas on non-empty filesets
         # (1) Always set default user quotas for all users, instead of quotas specific to each user
+        self.log.warning("Quota for user '%s' replaced with a default user quota", user)
         user = '*'
         # (2) User quotas in VOs are hardcoded to 100% of VO fileset quota
         if 'brussel/vo' in obj:

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -264,7 +264,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         self.log.info("URL of OceanStor REST API server: %s", self.api_url)
 
         # Initialize REST client without user/password
-        self.session = OceanStorRestClient(self.api_url, ssl_verify=False)
+        self.session = OceanStorRestClient(self.api_url)
         # Get token for this session with user/password
         self.session.client.get_x_auth_token(username, password)
 

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -1118,7 +1118,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         # (1) Always set default user quotas for all users, instead of quotas specific to each user
         self.log.warning("Quota for user '%s' replaced with a default user quota", user)
         user = '*'
-        # (2) User quotas in VOs are hardcoded to 100% of VO fileset quota
+        # (2) User quotas in VOs are temporarily frozen to 100% of VO fileset quota
         if 'brussel/vo' in obj:
             quota_parent, quota_id = self._get_quota(None, obj, 'fileset')
             if quota_id:
@@ -1176,6 +1176,12 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         quota_limits = {'soft': soft, 'hard': hard, 'inode_soft': inode_soft, 'inode_hard': inode_hard}
         self._set_quota(who=fileset_name, obj=fileset_path, typ='fileset', **quota_limits)
+
+        # TODO: remove once OceanStor supports setting user quotas on non-empty filesets
+        # User quotas in VOs are temporarily frozen to 100% of VO fileset quota
+        if 'brussel/vo' in fileset_path:
+            # Update default user quota in this VO to 100% of fileset quota
+            self._set_quota(who='*', obj=fileset_path, typ='user', **quota_limits)
 
     def _set_quota(self, who, obj, typ='user', **kwargs):
         """

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -1200,11 +1200,11 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         if quotas:
             # local path already has quotas of given type
             for quota_id in quotas:
-                self.log.debug("Sending request to update quota with ID: %s", quota_id)
+                self.log.debug("Sending request to update %s quota with ID: %s", typ, quota_id)
                 self._change_quota_api(quota_id, **kwargs)
         else:
             # create new quota of given type
-            self.log.debug("Sending request to create new quota for object ID: %s", quota_parent)
+            self.log.debug("Sending request to create new %s quota for object ID: %s", typ, quota_parent)
             self._new_quota_api(quota_parent, typ=typ, who=who, **kwargs)
 
         # Update quota list from this filesystem

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -1226,7 +1226,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         # Modify existing quota
         query_params['id'] = quota_id
         _, response = self.session.file_service.fs_quota.put(body=query_params)
-        self.log.info("Quota '%s' updated succesfully")
+        self.log.info("Quota '%s' updated succesfully", quota_id)
 
     def _new_quota_api(self, quota_parent, typ='user', who=None, **kwargs):
         """

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -1355,4 +1355,4 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             'soft_grace_time': grace,
         }
         _, response = self.session.file_service.fs_quota.put(body=query_params)
-        self.log.info("Grace period of quota '%s' updated succesfully: %s days", grace)
+        self.log.info("Grace period of quota '%s' updated succesfully: %s days", quota_id, grace)

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ if sys.version_info < (3, 3):
     install_requires.append('ipaddress')
 
 PACKAGE = {
-    'version': '0.5.0',
+    'version': '0.5.1',
     'author': [ad],
     'maintainer': [ad],
     'setup_requires': ['vsc-install'],


### PR DESCRIPTION
The results of a full sync with this version of `vsc-filesystem-oceanstor` can be found in the `test` filesystem. Mounted in `/mnt` of storctrl.

Changelog:
* add missing method: `get_filesystem_info()`
* add missing method: `get_fileset_info()`
* arguments of `OceanStorOperations.__init__()` use the same names as the parameters in its configuration file
* add workaround: all user quotas are set as user default quotas (user = `*`)
* add workaround: all user default quotas in VOs are set to 100% of corresponding VO fileset quota
* enable SSL certs verification
* do not create fileset quotas on fileset creation