### PR TITLE
Add support for vsc-filesystems-quota

### DIFF
--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -1190,12 +1190,14 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         return storage_quota
 
-    def list_quota(self, devices=None, update=False, alluser=False):  # pylint: disable=arguments-differ
+    def list_quota(self, devices=None, update=False, only_default=False):  # pylint: disable=arguments-differ
         """
         Get quota info for all filesystems for all quota types (fileset, user, group)
+        Regular quotas and default quotas are kept in separate class attributes
+        By default, return the list of regular quotas
 
         @type devices: list of filesystem names (if string: 1 filesystem; if None: all known filesystems)
-        @type alluser: bool to list user default quotas
+        @type only_default: bool to return list of default quotas
 
         set self.oceanstor_quotas to dict with
         : keys per filesystemName and value is dict with
@@ -1263,7 +1265,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         self.oceanstor_quotas.update(quotas)
         self.oceanstor_defaultquotas.update(default_quotas)
 
-        if alluser:
+        if only_default:
             return default_quotas
         else:
             return quotas

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -57,7 +57,7 @@ OCEANSTOR_API_PATH = ["api", "v2"]
 OCEANSTOR_JSON_SEP = (",", ":")
 
 # Quota type equivalents in OceanStor
-class OceanStorQuotaType(Enum):
+class QuotaType(Enum):
     fileset = 1
     user = 2
     group = 3
@@ -1157,7 +1157,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             else:
                 # Request quotas for this filesystem and all its filesets
                 dbg_prefix = ""
-                fs_quotas = {qt.name: dict() for qt in OceanStorQuotaType}
+                fs_quotas = {qt.name: dict() for qt in QuotaType}
 
                 query_params = {
                     "parent_type": OCEANSTOR_QUOTA_PARENT_TYPE["filesystem"],
@@ -1171,14 +1171,14 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                 if status and "data" in response:
                     # add each quota to its category in current filesystem
                     for quota_obj in response["data"]:
-                        quota_type = OceanStorQuotaType(quota_obj["quota_type"]).name
+                        quota_type = QuotaType(quota_obj["quota_type"]).name
                         quota_attributes = self._convert_quota_attributes(quota_obj)
                         if quota_attributes:
                             fs_quotas[quota_type].update({quota_obj["id"]: StorageQuota(**quota_attributes)})
 
                 quotas[fs_name] = fs_quotas
 
-            quota_count = ["%s = %s" % (qt.name, len(quotas[fs_name][qt.name])) for qt in OceanStorQuotaType]
+            quota_count = ["%s = %s" % (qt.name, len(quotas[fs_name][qt.name])) for qt in QuotaType]
             self.log.debug(
                 "%sQuota types for OceanStor filesystem '%s': %s", dbg_prefix, fs_name, ", ".join(quota_count)
             )
@@ -1205,7 +1205,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             errmsg = "getQuota: can't get quota on non-existing path '%s'" % quota_path
             self.log.raiseException(errmsg, OceanStorOperationError)
 
-        if typ not in [qt.name for qt in OceanStorQuotaType]:
+        if typ not in [qt.name for qt in QuotaType]:
             errmsg = "getQuota: unknown quota type '%s'" % typ
             self.log.raiseException(errmsg, OceanStorOperationError)
 
@@ -1364,7 +1364,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             errmsg = "setQuota: can't set quota on non-existing path '%s'" % quota_path
             self.log.raiseException(errmsg, OceanStorOperationError)
 
-        if typ not in [qt.name for qt in OceanStorQuotaType]:
+        if typ not in [qt.name for qt in QuotaType]:
             errmsg = "setQuota: unknown quota type '%s'" % typ
             self.log.raiseException(errmsg, OceanStorOperationError)
 
@@ -1417,7 +1417,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         # Create new quota
         query_params["parent_id"] = quota_parent
         query_params["parent_type"] = OCEANSTOR_QUOTA_PARENT_TYPE[parent_type]
-        query_params["quota_type"] = OceanStorQuotaType[typ].value
+        query_params["quota_type"] = QuotaType[typ].value
 
         if typ in ["user", "group"]:
             # settings for user/group quotas
@@ -1526,7 +1526,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             errmsg = "setGrace: can't set grace on non-existing path '%s'" % quota_path
             self.log.raiseException(errmsg, OceanStorOperationError)
 
-        if typ not in [qt.name for qt in OceanStorQuotaType]:
+        if typ not in [qt.name for qt in QuotaType]:
             errmsg = "setGrace: unknown quota type '%s'" % typ
             self.log.raiseException(errmsg, OceanStorOperationError)
 
@@ -1570,7 +1570,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         @type quota: StorageQuota named tuple
 
-        @returns: grace expiration on blocks and grace expiration on files 
+        @returns: grace expiration on blocks and grace expiration on files
         """
 
         block_expire = OceanStorOperations._get_grace_expiration(
@@ -1614,4 +1614,3 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             expired = (False, None)
 
         return expired
-

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -1210,7 +1210,11 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                         quota_type = QuotaType(quota_obj["quota_type"]).name
                         quota_attributes = self._convert_quota_attributes(quota_obj)
                         if quota_attributes:
-                            fs_quotas[quota_type].update({quota_obj["id"]: StorageQuota(**quota_attributes)})
+                            # add any non-default quotas as is
+                            if quota_attributes["ownerName"] != "All User":
+                                fs_quotas[quota_type].update(
+                                    {quota_obj["id"]: StorageQuota(**quota_attributes)}
+                                )
 
                 quotas[fs_name] = fs_quotas
 

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -94,15 +94,6 @@ OCEANSTOR_QUOTA_DOMAIN_TYPE = {
     "NIS": 3,
 }
 
-# Soft quota to hard quota factor
-OCEANSTOR_QUOTA_FACTOR = 1.05
-
-# NFS lookup cache lifetime in seconds
-NFS_LOOKUP_CACHE_TIME = 60
-
-# Keyword identifying the VSC network zone
-VSC_NETWORK_LABEL = "VSC"
-
 # Quota settings
 StorageQuota = namedtuple(
     'StorageQuota',
@@ -127,6 +118,15 @@ StorageQuota = namedtuple(
         'parentType',
     ],
 )
+
+# Soft quota to hard quota factor
+OCEANSTOR_QUOTA_FACTOR = 1.05
+# NFS lookup cache lifetime in seconds
+NFS_LOOKUP_CACHE_TIME = 60
+# Keyword identifying the VSC network zone
+VSC_NETWORK_LABEL = "VSC"
+# Label of local filesystems items with their OceanStor IDs
+LOCAL_FS_OCEANSTOR = "oceanstor"
 
 
 class OceanStorClient(Client):
@@ -853,7 +853,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             self.list_filesystems()
 
         # Add filesystem name in OceanStor to list of attributes of local filesystems
-        self.localfilesystemnaming.append("oceanstor")
+        self.localfilesystemnaming.append(LOCAL_FS_OCEANSTOR)
 
         # NFS share paths and their IDs
         oceanstor_shares = self.list_nfs_shares()
@@ -921,7 +921,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         local_fs = self.what_filesystem(local_path)
 
         # Check NFS mount source
-        oceanstor_id = local_fs[self.localfilesystemnaming.index("oceanstor")]
+        oceanstor_id = local_fs[self.localfilesystemnaming.index(LOCAL_FS_OCEANSTOR)]
         if oceanstor_id is None:
             errmsg = "NFS mount of '%s' is not from OceanStor" % local_path
             self.log.raiseException(errmsg, OceanStorOperationError)
@@ -955,8 +955,8 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         self._local_filesystems()
 
-        for mount in [fs for fs in self.localfilesystems if fs[self.localfilesystemnaming.index("oceanstor")]]:
-            mount_id = mount[self.localfilesystemnaming.index("oceanstor")]
+        for mount in [fs for fs in self.localfilesystems if fs[self.localfilesystemnaming.index(LOCAL_FS_OCEANSTOR)]]:
+            mount_id = mount[self.localfilesystemnaming.index(LOCAL_FS_OCEANSTOR)]
             mount_path = mount[self.localfilesystemnaming.index("mountpoint")]
             if mount_id == fileset_id:
                 # fileset is directly mounted here

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -657,7 +657,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         if quota_id in fileset_quotas:
             quota_obj = fileset_quotas[quota_id]
             # verify that this fileset quota is attached to a dtree
-            if quota_obj.parentType == 16445:
+            if quota_obj.parentType == OCEANSTOR_QUOTA_PARENT_TYPE["dtree"]:
                 fileset_id = quota_obj.parentId
 
         if fileset_id is None:
@@ -1184,7 +1184,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             self.log.raiseException(errmsg, KeyError)
 
         # Extra filesetname attribute needed by AP
-        if storage_quota["parentType"] == 16445:
+        if storage_quota["parentType"] == OCEANSTOR_QUOTA_PARENT_TYPE["dtree"]:
             # set to parent fileset ID of quota
             storage_quota["filesetname"] = storage_quota["parentId"]
         else:

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -599,6 +599,23 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         return None
 
+    def get_fileset_name(self, fileset_id, filesystem_name):
+        """
+        Return name of fileset
+
+        @type fileset_id: string with fileset ID
+        @type filesystem_name: string with device name
+        """
+        self.list_filesets(devices=filesystem_name)
+
+        try:
+            fileset_name = self.oceanstor_filesets[filesystem_name][fileset_id]['name']
+        except KeyError:
+            errmsg = "Fileset ID '%s' not found in OceanStor filesystem '%s'" % (fileset_id, filesystem_name)
+            self.log.raiseException(errmsg, OceanStorOperationError)
+
+        return fileset_name
+
     def list_nfs_shares(self, filesystemnames=None, update=False):
         """
         Get all NFS shares in given filesystems

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -281,8 +281,6 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         """
         super(OceanStorOperations, self).__init__()
 
-        self.dry_run = False
-
         self.supportedfilesystems = ["nfs", "nfs4"]
         self.ignorerealpathmismatch = True  # allow working through symlinks
 

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -264,7 +264,9 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         self.oceanstor_storagepools = dict()
         self.oceanstor_filesystems = dict()
         self.oceanstor_filesets = dict()
+
         self.oceanstor_quotas = dict()
+        self.quota_types = Typ2Param
 
         self.oceanstor_nfsshares = dict()
         self.oceanstor_nfsclients = dict()

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -298,6 +298,8 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         self.account = account
 
+        self.vsc = VSC()
+
         # OceanStor API URL
         self.api_url = os.path.join(url, *OCEANSTOR_API_PATH)
         self.log.info("URL of OceanStor REST API server: %s", self.api_url)
@@ -674,8 +676,6 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         @type quota_id: string with quota ID
         @type filesystem_name: string with device name
         """
-        owner_id = None
-
         quotas = self.list_quota(devices=filesystem_name)
 
         if quota_id in quotas[filesystem_name][Typ2Param.USR.value]:
@@ -686,10 +686,8 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             errmsg = "User/Group quota '%s' not found in OceanStor filesystem '%s'" % (quota_id, filesystem_name)
             self.log.raiseException(errmsg, OceanStorOperationError)
 
-        vsc = VSC()
-        owner_name = usrgrp_quota.ownerName
-        owner_id = vsc.user_uid_institute_map[owner_name[:3]][0] + int(owner_name[3:])
-        self.log.debug("Quota '%s' is owned by: [%s] %s", quota_id, owner_id, owner_name)
+        owner_id = self.vsc.uid_to_uid_number(usrgrp_quota.ownerName)
+        self.log.debug("Quota '%s' is owned by: [%s] %s", quota_id, owner_id, usrgrp_quota.ownerName)
 
         return owner_id
 

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -1692,6 +1692,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             # over quota
             if soft < hard:
                 # grace not expired: we only know the maximum grace time
+                # TODO: review method to retrieve the actual remaining grace time
                 grace_time = grace * 24 * 3600
             else:
                 # grace expired

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -1320,9 +1320,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             elif len(fileset) > 1:
                 # there cannot be more than one match for any path
                 errmsg = "getQuota: found multiple filesets mathing path '%s' in OceanStor filesystem '%s': %s"
-                self.log.raiseException(
-                    errmsg % (quota_path, ostor_mount, ",".join(fileset)), OceanStorOperationError
-                )
+                self.log.raiseException(errmsg % (quota_path, ostor_mount, ",".join(fileset)), OceanStorOperationError)
             else:
                 # no fileset found, continue looking up the path
                 dbgmsg = "getQuota: no fileset found matching path '%s' in OceanStor filesystem '%s'"

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -1177,13 +1177,11 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         # Filter by filesystem name (devices in GPFS)
         if devices is None:
             filesystems = self.list_filesystems()
-            filesystemnames = list(filesystems.keys())
+            devices = list(filesystems.keys())
         elif isinstance(devices, str):
-            filesystemnames = [devices]
-        else:
-            filesystemnames = devices
+            devices = [devices]
 
-        filter_fs = self.select_filesystems(filesystemnames)
+        filter_fs = self.select_filesystems(devices)
         self.log.debug("Seeking quotas in filesystems IDs: %s", ", ".join(filter_fs))
 
         quotas = dict()

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -62,10 +62,12 @@ class QuotaType(Enum):
     user = 2
     group = 3
 
+
 class Typ2Param(Enum):
     FILESET = 'fileset'
     USR = 'user'
     GRP = 'group'
+
 
 OCEANSTOR_QUOTA_PARENT_TYPE = {
     "filesystem": 40,
@@ -102,11 +104,30 @@ NFS_LOOKUP_CACHE_TIME = 60
 VSC_NETWORK_LABEL = "VSC"
 
 # Quota settings
-StorageQuota = namedtuple('StorageQuota',
-    ['id', 'name', 'quota', 'filesetname',
-     'blockUsage', 'blockQuota', 'blockLimit', 'blockInDoubt', 'blockGrace',
-     'filesUsage', 'filesQuota', 'filesLimit', 'filesInDoubt', 'filesGrace',
-     'ownerName', 'ownerType', 'parentId', 'parentType'])
+StorageQuota = namedtuple(
+    'StorageQuota',
+    [
+        'id',
+        'name',
+        'quota',
+        'filesetname',
+        'blockUsage',
+        'blockQuota',
+        'blockLimit',
+        'blockInDoubt',
+        'blockGrace',
+        'filesUsage',
+        'filesQuota',
+        'filesLimit',
+        'filesInDoubt',
+        'filesGrace',
+        'ownerName',
+        'ownerType',
+        'parentId',
+        'parentType',
+    ],
+)
+
 
 class OceanStorClient(Client):
     """Client for OceanStor REST API"""
@@ -1131,7 +1152,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         - vstore_id: <ignored>
         """
         try:
-            byte_conversion = 1024**quota["space_unit_type"]
+            byte_conversion = 1024 ** quota["space_unit_type"]
         except KeyError as err:
             self.log.raiseException("Missing space_unit_type attribute in quota object", KeyError)
 
@@ -1221,9 +1242,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                         if quota_attributes:
                             # add any non-default quotas as is
                             if quota_attributes["ownerName"] != "All User":
-                                fs_quotas[quota_type].update(
-                                    {quota_obj["id"]: StorageQuota(**quota_attributes)}
-                                )
+                                fs_quotas[quota_type].update({quota_obj["id"]: StorageQuota(**quota_attributes)})
 
                 quotas[fs_name] = fs_quotas
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ import vsc.install.shared_setup as shared_setup
 from vsc.install.shared_setup import ad
 
 install_requires = [
-    'vsc-config',
+    'vsc-config >= 3.10.7',
     'vsc-filesystems',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ if sys.version_info < (3, 3):
     install_requires.append('ipaddress')
 
 PACKAGE = {
-    'version': '0.5.7',
+    'version': '0.6.0',
     'author': [ad],
     'maintainer': [ad],
     'setup_requires': ['vsc-install'],

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,9 @@ install_requires = [
 if sys.version_info < (3, 3):
     # Backport of the 3.3+ ipaddress module
     install_requires.append('ipaddress')
+if sys.version_info < (3, 4):
+    # Backport of the 3.4+ Enum module 
+    install_requires.append('enum34')
 
 PACKAGE = {
     'version': '0.6.0',

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ import vsc.install.shared_setup as shared_setup
 from vsc.install.shared_setup import ad
 
 install_requires = [
+    'vsc-config',
     'vsc-filesystems',
 ]
 


### PR DESCRIPTION
Changelog:
* add dry run mode where PUT and POST queries are not executed
* use global Enums instead of dicts for the quota type labels, analogue to other `XxxxOperations` classes
* add `StorageQuota` to structure quota data stored in OceanStorOperations, analogue to other `XxxxOperations` classes
* all list methods use the `devices` argument as the name of the filesystem, analogue to other `XxxxOperations` classes
* add `pool` argument to methods supporting selecting the storage pool (replaces `devices`)
* add methods: `determine_grace_period`, `get_fileset_name`, `get_quota_fileset` and `get_quota_owner` which are needed by vsc-filesystems-quota
* ~~ignore default user quotas in `list_quota()` and do not include those in `oceanstor_quotas` dictionary~~
* `list_quota()` populates 2 lists in `OceanStorOperations`, one for regular quotas and another for user default quotas
* the default behaviour of `list_quota()` is to return the list of regular quotas, which is expected by vsc-filesystems-quota
* remove workaround replacing all requests to set user quotas with default quotas (see update below)

**update**
Ignoring the default quotas in `list_quota()` had some bad side effects in our workarounds for the user quotas. 
So I implemented a different solution. The workaround replacing all requests to set user quotas with default quotas is removed, instead we now try to carry out the creation/update of the regular user quota using the following approach:

1. all filesets get a default user quota on creation (unchanged behaviour)
2. creating/updating the fileset quota in a VO automatically updates the default user quota to 100% of its value (unchanged behaviour)
3. updating a user quota is carried out because they are automatically created whenever the users adds data to the fileset, so there are only two possible outcomes:
    1. the regular user quota already exists (user has data): in this case the quota can be updated
    2. the regular user quota does not exist (user has no data): in this case we can ignore the error as the default quota will come into play as soon as the user adds any data