### PR TITLE
Consolidate VSC fileset name conversions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ if sys.version_info < (3, 4):
     install_requires.append('enum34')
 
 PACKAGE = {
-    'version': '0.6.4',
+    'version': '0.6.5',
     'author': [ad],
     'maintainer': [ad],
     'setup_requires': ['vsc-install'],


### PR DESCRIPTION
Changelog:
* gather all fileset name conversions in a global list `BANNED_FILESET_NAMES`
* disallow creation of new filesets with names that conflict with those filesets subject to VSC name conversion
* `list_filesets` accepts VSC fileset names as `filesetnames` and converts them to OceanStor names