### PR TITLE
Filter filesystems by account

### DIFF
--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -419,21 +419,12 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         Set self.oceanstor_filesystems as dict with
         : keys per filesystemName and value is dict with
-        :: keys returned by OceanStor:
-        - atime_update_mode
-        - dentry_table_type
-        - dir_split_bitwidth
-        - dir_split_policy
+        :: selected keys from OceanStor:
         - id
-        - is_show_snap_dir
         - name
-        - qos_policy_id
-        - rdc
-        - record_id
-        - root_split_bitwidth
-        - running_status
         - storage_pool_id
         """
+        fs_attrs = ["id", "name", "storage_pool_id"]
 
         # Filter by requested storage pool
         # Support special case 'all' for downstream compatibility
@@ -455,10 +446,14 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             dbg_prefix = ""
             filesystems = dict()
             for sp_id in filter_sp:
-                filter_json = [{"storage_pool_id": str(sp_id)}]
+                # Query filesystems that belong to our account
+                filter_json = [{"account_id": self.account["id"], "storage_pool_id": str(sp_id)}]
                 filter_json = json.dumps(filter_json, separators=OCEANSTOR_JSON_SEP)
-                _, response = self.session.file_service.file_systems.get(filter=filter_json)
-                filesystems.update({fs["name"]: fs for fs in response["data"]})
+                _, response = self.session.converged_service.namespaces.get(filter=filter_json)
+                # Save selection of attributes for this filesystem
+                for fs in response["data"]:
+                    new_fs_record = {attr: fs[attr] for attr in fs_attrs}
+                    filesystems.update({fs["name"]: new_fs_record})
 
             # Update filesystems in the selected pools
             self.oceanstor_filesystems = filesystems

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -309,8 +309,6 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         self.oceanstor_nfsclients = dict()
         self.oceanstor_nfsservers = dict()
 
-        self.account = account
-
         self.vsc = VSC()
 
         # OceanStor API URL
@@ -321,6 +319,20 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         self.session = OceanStorRestClient(self.api_url)
         # Get token for this session with user/password
         self.session.client.get_x_auth_token(username, password)
+
+        # Account details
+        self.account = self.get_account_id(account)
+
+    def get_account_id(self, account_name):
+        """
+        Query the ID an account name
+        """
+        filter_json = [{"name": account_name}]
+        filter_json = json.dumps(filter_json, separators=OCEANSTOR_JSON_SEP)
+        _, response = self.session.account.accounts.get(filter=filter_json)
+        ostor_account = response["data"][0]
+
+        return ostor_account
 
     def list_storage_pools(self, update=False):
         """
@@ -761,7 +773,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                 filter_json = [{"fs_id": str(fs_id)}]
                 filter_json = json.dumps(filter_json, separators=OCEANSTOR_JSON_SEP)
                 query_params = {
-                    "account_name": self.account,
+                    "account_name": self.account["name"],
                     "filter": filter_json,
                 }
                 _, response = self.session.nas_protocol.nfs_share_list.get(**query_params)
@@ -827,7 +839,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                 filter_json = [{"share_id": str(ns_id)}]
                 filter_json = json.dumps(filter_json, separators=OCEANSTOR_JSON_SEP)
                 query_params = {
-                    "account_name": self.account,
+                    "account_name": self.account["name"],
                     "filter": filter_json,
                 }
                 _, response = self.session.nas_protocol.nfs_share_auth_client_list.get(**query_params)

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ if sys.version_info < (3, 4):
     install_requires.append('enum34')
 
 PACKAGE = {
-    'version': '0.6.5',
+    'version': '0.6.6',
     'author': [ad],
     'maintainer': [ad],
     'setup_requires': ['vsc-install'],


### PR DESCRIPTION
Changelog:
* Query all details (*i.e.* ID) for our account on initialization of `OceanStorOperations`
* switch `list_filesystem` to use the `converged_service.namespaces` REST interface, which allows to filter filesystems by account ID
* limit the attributes stored for each filesystem to `name`, `id` and `storage_pool_id`