### PR TITLE
set default quotas from configuration in VscStorage

### DIFF
--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -310,7 +310,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         self.vsc = VSC()
         self.vscstorage = VscStorage()
-        self.institutes = [institute for institute in self.vscstorage if not institute.startswith('VSC')]
+        self.host_institute = os.getenv('VSC_INSTITUTE_LOCAL')
 
         # OceanStor API URL
         self.api_url = os.path.join(url, *OCEANSTOR_API_PATH)
@@ -1103,9 +1103,8 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         try:
             vsc_fileset_storage = [
                 stor
-                for inst in self.institutes
-                for stor in self.vscstorage[inst].values()
-                if stor.backend == 'oceanstor' and dtree_fullpath.startswith(stor.backend_mount_point)
+                for stor in self.vscstorage[self.host_institute].values()
+                if stor.backend == LOCAL_FS_OCEANSTOR and dtree_fullpath.startswith(stor.backend_mount_point)
             ][0]
         except IndexError as err:
             errmsg = "Could not find VSC storage for new fileset '%s' at: %s"

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -43,7 +43,7 @@ from enum import Enum
 from ipaddress import IPv4Address, AddressValueError
 from socket import gethostbyname
 
-from vsc.config.base import DEFAULT_INODE_MAX, VSC, VscStorage
+from vsc.config.base import DEFAULT_INODE_MAX, VO_INFIX, VSC, VscStorage
 from vsc.filesystem.posix import PosixOperations, PosixOperationError
 from vsc.utils import fancylogger
 from vsc.utils.patterns import Singleton
@@ -1111,7 +1111,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             errmsg = "Could not find VSC storage for new fileset '%s' at: %s"
             self.log.raiseException(errmsg % (ostor_dtree_name, ostor_parentdir), OceanStorOperationError)
         else:
-            if ostor_dtree_name[1:3] == 'vo':
+            if ostor_dtree_name[1:3] == VO_INFIX:
                 block_hard = vsc_fileset_storage.quota_vo
                 inode_hard = vsc_fileset_storage.quota_vo_inode
             else:

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -43,7 +43,7 @@ from enum import Enum
 from ipaddress import IPv4Address, AddressValueError
 from socket import gethostbyname
 
-from vsc.config.base import DEFAULT_INODE_MAX, VSC
+from vsc.config.base import DEFAULT_INODE_MAX, VSC, VscStorage
 from vsc.filesystem.posix import PosixOperations, PosixOperationError
 from vsc.utils import fancylogger
 from vsc.utils.patterns import Singleton
@@ -121,8 +121,7 @@ StorageQuota = namedtuple(
 
 # Soft quota to hard quota factor
 OCEANSTOR_QUOTA_FACTOR = 1.05
-# Default quota values
-DEFAULT_USER_BLOCK = 1048576  # bytes
+# Default quota grace period
 DEFAULT_GRACE_DAYS = 7
 # NFS lookup cache lifetime in seconds
 NFS_LOOKUP_CACHE_TIME = 60
@@ -310,6 +309,8 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         self.oceanstor_nfsservers = dict()
 
         self.vsc = VSC()
+        self.vscstorage = VscStorage()
+        self.institutes = [institute for institute in self.vscstorage if not institute.startswith('VSC')]
 
         # OceanStor API URL
         self.api_url = os.path.join(url, *OCEANSTOR_API_PATH)
@@ -1097,13 +1098,35 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             # wait for NFS lookup cache to expire to be able to access new fileset
             time.sleep(NFS_LOOKUP_CACHE_TIME)
 
-        # Set default user quota: 1MB for blocks soft limit and inodes_max for inodes hard limit
+        # Set default user quota on blocks soft limit and inodes hard limit from settings in VscStorage
         # TODO: remove once OceanStor supports setting user quotas on non-empty filesets
-        block_soft = DEFAULT_USER_BLOCK
-        inodes_soft = int(inodes_max // OCEANSTOR_QUOTA_FACTOR)
-        self.set_user_quota(block_soft, "*", obj=dtree_fullpath, inode_soft=inodes_soft)
-        grace_time = DEFAULT_GRACE_DAYS * 24 * 3600
-        self.set_user_grace(dtree_fullpath, grace=grace_time, who="*")
+        try:
+            vsc_fileset_storage = [
+                stor
+                for inst in self.institutes
+                for stor in self.vscstorage[inst].values()
+                if stor.backend == 'oceanstor' and dtree_fullpath.startswith(stor.backend_mount_point)
+            ][0]
+        except IndexError as err:
+            errmsg = "Could not find VSC storage for new fileset '%s' at: %s"
+            self.log.raiseException(errmsg % (ostor_dtree_name, ostor_parentdir), OceanStorOperationError)
+        else:
+            if ostor_dtree_name[1:3] == 'vo':
+                block_hard = vsc_fileset_storage.quota_vo
+                inode_hard = vsc_fileset_storage.quota_vo_inode
+            else:
+                block_hard = vsc_fileset_storage.quota_user
+                inode_hard = vsc_fileset_storage.quota_user_inode
+
+            block_hard *= 1024  # convert from kB to bytes
+            block_soft = int(block_hard // OCEANSTOR_QUOTA_FACTOR)
+            inode_soft = int(inode_hard // OCEANSTOR_QUOTA_FACTOR)
+            self.set_user_quota(
+                block_soft, "*", obj=dtree_fullpath, hard=block_hard, inode_soft=inode_soft, inode_hard=inode_hard
+            )
+
+            grace_time = DEFAULT_GRACE_DAYS * 24 * 3600
+            self.set_user_grace(dtree_fullpath, grace=grace_time, who="*")
 
     def make_fileset_api(self, fileset_name, filesystem_name, parent_dir="/"):
         """

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -310,7 +310,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         self.vsc = VSC()
         self.vscstorage = VscStorage()
-        self.host_institute = os.getenv('VSC_INSTITUTE_LOCAL')
+        self.host_institute = vsc.options.options.host_institute
 
         # OceanStor API URL
         self.api_url = os.path.join(url, *OCEANSTOR_API_PATH)

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ if sys.version_info < (3, 4):
     install_requires.append('enum34')
 
 PACKAGE = {
-    'version': '0.6.6',
+    'version': '0.6.7',
     'author': [ad],
     'maintainer': [ad],
     'setup_requires': ['vsc-install'],


### PR DESCRIPTION
New filesets are currently created with a default quota of 1 MB. The sync script will set the correct user quotas but only after files owned by the user exist in the fileset. This is not reliable as new syncs are triggered infrequently, only by account changes.

This PR changes the default user quota set in new filesets to follow the configuration settings defined in `VscStorage`. The default quota is applied not only to blocks but also to inodes.

Tested on the `test` filesystem in pixiu.