### PR TITLE
add support for snapshoting namespaces

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ resources:
       type: github
       endpoint: vub-hpc
       name: vub-hpc/azure-pipelines-template
-      ref: refs/heads/legacy
+      ref: refs/heads/vsc
     # add hpcugent/vsc-config repo
     - repository: vsc-config
       type: github
@@ -20,7 +20,7 @@ resources:
 
 # run tox test jobs
 jobs:
-  - template: run-tox-env.yml@vub-hpc
+  - template: run-tox-vsc-env.yml@vub-hpc
     parameters:
       jobs:
         py39:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ resources:
       type: github
       endpoint: vub-hpc
       name: vub-hpc/azure-pipelines-template
-      ref: refs/heads/vsc
+      ref: refs/heads/legacy
     # add hpcugent/vsc-config repo
     - repository: vsc-config
       type: github
@@ -20,7 +20,7 @@ resources:
 
 # run tox test jobs
 jobs:
-  - template: run-tox-vsc-env.yml@vub-hpc
+  - template: run-tox-env.yml@vub-hpc
     parameters:
       jobs:
         py39:

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -176,7 +176,7 @@ class OceanStorClient(Client):
         }
 
         status = None
-        response = {"data": list(), "result": dict()}
+        response = {"data": [], "result": {}}
         page_items = query_range["limit"]
 
         while page_items == query_range["limit"]:
@@ -297,18 +297,18 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         self.supportedfilesystems = ["nfs", "nfs4"]
         self.ignorerealpathmismatch = True  # allow working through symlinks
 
-        self.oceanstor_storagepools = dict()
-        self.oceanstor_namespaces = dict()
-        self.oceanstor_filesystems = dict()
-        self.oceanstor_filesets = dict()
+        self.oceanstor_storagepools = {}
+        self.oceanstor_namespaces = {}
+        self.oceanstor_filesystems = {}
+        self.oceanstor_filesets = {}
 
-        self.oceanstor_quotas = dict()
-        self.oceanstor_defaultquotas = dict()
+        self.oceanstor_quotas = {}
+        self.oceanstor_defaultquotas = {}
         self.quota_types = Typ2Param
 
-        self.oceanstor_nfsshares = dict()
-        self.oceanstor_nfsclients = dict()
-        self.oceanstor_nfsservers = dict()
+        self.oceanstor_nfsshares = {}
+        self.oceanstor_nfsclients = {}
+        self.oceanstor_nfsservers = {}
 
         self.vsc = VSC()
         self.vscstorage = VscStorage()
@@ -390,7 +390,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         _, response = self.session.api.v2.data_service.storagepool.get()
 
         # Organize in a dict by storage pool name
-        storage_pools = dict()
+        storage_pools = {}
         for sp in response["storagePools"]:
             storage_pools.update({sp["storagePoolName"]: sp})
 
@@ -638,7 +638,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         filter_fs = self.select_filesystems(devices, pool=pool)
         self.log.debug("Seeking dtree filesets in filesystems: %s", ", ".join(filter_fs))
 
-        dtree_filesets = dict()
+        dtree_filesets = {}
         for fs_name in filter_fs:
             if not update and fs_name in self.oceanstor_filesets:
                 # Use cached dtree fileset data and filter by filesystem name
@@ -819,7 +819,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         filter_fs = self.select_filesystems(filesystemnames)
         self.log.debug("Seeking NFS shares in filesystems: %s", ", ".join(filter_fs))
 
-        nfs_shares = dict()
+        nfs_shares = {}
         for fs_name, fs_id in filter_fs.items():
             if not update and fs_name in self.oceanstor_nfsshares:
                 # Use cached data
@@ -885,7 +885,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         self.log.debug("Seeking NFS clients for NFS shares: %s", ", ".join(str(i) for i in filter_ns))
 
-        nfs_clients = dict()
+        nfs_clients = {}
         for ns_id in filter_ns:
             if not update and ns_id in self.oceanstor_nfsclients:
                 # Use cached data
@@ -1350,8 +1350,8 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         self.log.debug("Seeking quotas in filesystems IDs: %s", ", ".join(filter_fs))
 
         # Keep regular quotas and user default quotas in separate lists
-        quotas = dict()
-        default_quotas = dict()
+        quotas = {}
+        default_quotas = {}
 
         for fs_name, fs_id in filter_fs.items():
             if not update and fs_name in self.oceanstor_quotas and fs_name in self.oceanstor_defaultquotas:
@@ -1362,8 +1362,8 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             else:
                 # Request quotas for this filesystem and all its filesets
                 dbg_prefix = ""
-                fs_quotas = {qt.name: dict() for qt in QuotaType}
-                fs_default_quotas = {qt.name: dict() for qt in QuotaType}
+                fs_quotas = {qt.name: {} for qt in QuotaType}
+                fs_default_quotas = {qt.name: {} for qt in QuotaType}
 
                 query_params = {
                     "parent_type": OCEANSTOR_QUOTA_PARENT_TYPE["filesystem"],

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -323,16 +323,20 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         self.session.api.v2.client.get_x_auth_token(username, password)
 
         # Account details
-        self.account = self.get_account_id(account)
+        self.account = self.get_account_info(account)
 
-    def get_account_id(self, account_name):
+    def get_account_info(self, account_name):
         """
-        Query the ID an account name
+        Query the details of an account by name
         """
         filter_json = [{"name": account_name}]
         filter_json = json.dumps(filter_json, separators=OCEANSTOR_JSON_SEP)
         _, response = self.session.api.v2.account.accounts.get(filter=filter_json)
-        ostor_account = response["data"][0]
+        try:
+            ostor_account = response["data"][0]
+        except IndexError:
+            errmsg = "OceanStor account not found: %s" % account_name
+            self.log.raiseException(errmsg, OceanStorOperationError)
 
         return ostor_account
 

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -472,8 +472,8 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                 # Save selection of attributes for this namespace
                 namespaces[acc_id] = {ns["name"]: {attr: ns[attr] for attr in ns_attrs} for ns in response["data"]}
 
-        # Update cache of namespaces with the selected accounts
-        self.oceanstor_namespaces.update(namespaces)
+                # Update cache of namespaces with this account
+                self.oceanstor_namespaces[acc_id] = namespaces[acc_id]
 
         # Filter on storage pools
         # Support special case 'all' for downstream compatibility
@@ -678,13 +678,13 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
                 dtree_filesets[fs_name] = fs_dtree
 
+                # Update cache of dtree filesets in the selected filesystem
+                self.oceanstor_filesets[fs_name] = fs_dtree
+
             dt_names = [dt["name"] for dt in dtree_filesets[fs_name].values()]
             self.log.debug(
                 "%sDtree filesets in OceanStor filesystem '%s': %s", dbg_prefix, fs_name, ", ".join(dt_names)
             )
-
-        # Update dtree filesets in the selected filesystems
-        self.oceanstor_filesets.update(dtree_filesets)
 
         # Filter by fileset name
         if filesetnames is not None:
@@ -858,11 +858,11 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                 fs_nfs_shares = {ns["id"]: ns for ns in response["data"]}
                 nfs_shares[fs_name] = fs_nfs_shares
 
+                # Update cache of NFS shares in selected filesystem
+                self.oceanstor_nfsshares[fs_name] = fs_nfs_shares
+
             nfs_desc = [f"'{ns['description']}'" for ns in nfs_shares[fs_name].values()]
             self.log.debug("%sNFS shares in OceanStor filesystem '%s': %s", dbg_prefix, fs_name, ", ".join(nfs_desc))
-
-        # Store all NFS shares in selected filesystems
-        self.oceanstor_nfsshares.update(nfs_shares)
 
         return nfs_shares
 
@@ -924,13 +924,13 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                 share_client = {nc["id"]: nc for nc in response["data"]}
                 nfs_clients[ns_id] = share_client
 
+                # Update cache of NFS clients in selected share
+                self.oceanstor_nfsclients[ns_id] = share_client
+
             nc_access_name = [f"'{nc['access_name']}'" for nc in nfs_clients[ns_id].values()]
             self.log.debug(
                 "%sNFS clients for OceanStor NFS share ID '%s': %s", dbg_prefix, ns_id, ", ".join(nc_access_name)
             )
-
-        # Store all NFS shares in selected filesystems
-        self.oceanstor_nfsclients.update(nfs_clients)
 
         return nfs_clients
 
@@ -1420,17 +1420,17 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                                 # regular quota
                                 fs_quotas[quota_type].update(quota_entry)
 
-                default_quotas[fs_name] = fs_default_quotas
                 quotas[fs_name] = fs_quotas
+                default_quotas[fs_name] = fs_default_quotas
+
+                # Update cache of quotas in selected filesystem
+                self.oceanstor_quotas[fs_name] = fs_quotas
+                self.oceanstor_defaultquotas[fs_name] = fs_default_quotas
 
             quota_count = [f"{qt.name} = {len(quotas[fs_name][qt.name])}" for qt in QuotaType]
             self.log.debug(
                 "%sQuota types for OceanStor filesystem '%s': %s", dbg_prefix, fs_name, ", ".join(quota_count)
             )
-
-        # Store all regular quotas in selected filesystems
-        self.oceanstor_quotas.update(quotas)
-        self.oceanstor_defaultquotas.update(default_quotas)
 
         if only_default:
             return default_quotas

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -492,6 +492,27 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         return namespaces
 
+    def get_namespace_info(self, namespace):
+        """
+        Get all the relevant information for a given OceanStor namespace.
+        There is a single namespace in OceanStor, so there will be only namespace matching across all accounts
+
+        @type namespace: name of the namespace in OceanStor
+
+        @returns: dictionary with the namespace information
+
+        @raise OceanStorOperationError: if there is no namespace with the given name
+        """
+        oceanstor_namespaces = self.list_namespaces()
+        account = [ns for ns in oceanstor_namespaces if namespace in oceanstor_namespaces[ns]]
+
+        try:
+            return oceanstor_namespaces[account[0]][namespace]
+        except (KeyError, IndexError):
+            errmsg = "OceanStor has no information for namespace %s" % (namespace)
+            self.log.raiseException(errmsg, OceanStorOperationError)
+            return None
+
     def list_filesystems(self, device=None, pool=None, update=False):
         """
         List filesystems in OceanStor owned by our account

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -478,7 +478,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         # Filter on storage pools
         # Support special case 'all' for downstream compatibility
         if pool is None or pool == "all":
-            storage_pools = self.list_storage_pools()
+            storage_pools = self.list_storage_pools(update=update)
             pool = list(storage_pools.keys())
         filter_pool = self.select_storage_pools(pool, byid=True)
         self.log.debug("Filtering filesystems in storage pools with IDs: %s", ", ".join(str(i) for i in filter_pool))

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -230,7 +230,7 @@ class OceanStorClient(Client):
             exit_code = result
             ec_msg_desc = ""
             if "data" in response:
-                ec_msg_desc = response["data"]["errorMsg"]
+                ec_msg_desc = response["data"].get("errorMsg", "")
                 if "suggestion" in response["data"]:
                     ec_msg_desc += " " + response["data"]["suggestion"]
         else:

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -1894,6 +1894,22 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         return expired
 
+    def list_namespace_snapshots(self, namespace):
+        """
+        List the snapshots in the given namespace
+
+        @type namespace: name of the namespace
+        """
+
+        ns = self.get_namespace_info(namespace)
+        filter_json = {"namespace_id": int(ns["id"])}
+        filter_json = json.dumps([filter_json], separators=OCEANSTOR_JSON_SEP)
+        _, response = self.session.api.v2.converged_service.snapshots.get(pagination=True, filter=filter_json)
+
+        snapshots = [snap["name"] for snap in response["data"]]
+
+        return snapshots
+
     def list_snapshots(self, filesystem, fileset=None):
         """
         List the snapshots in the given filesystem or dtree fileset

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -340,6 +340,17 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         return ostor_account
 
+    def list_active_accounts(self):
+        """
+        Query active accounts
+        Return list of tuples with name and ID of active account
+        """
+        _, response = self.session.api.v2.account.accounts.get(pagination=True)
+
+        accounts = [(acc["name"], acc["id"]) for acc in response["data"] if acc["status"] == "Active"]
+
+        return accounts
+
     def list_storage_pools(self, update=False):
         """
         List available storage pools in OceanStor

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -211,7 +211,7 @@ class OceanStorClient(Client):
         try:
             status, response = super(OceanStorClient, self).request(method, url, body, headers, content_type)
         except HTTPError as err:
-            errmsg = "OceanStor query failed with HTTP error: %s (%s)" % (err.reason, err.code)
+            errmsg = f"OceanStor query failed with HTTP error: {err.reason} ({err.code})"
             fancylogger.getLogger().error(errmsg)
             raise
 
@@ -219,7 +219,7 @@ class OceanStorClient(Client):
         try:
             result = response["result"]
         except (KeyError, TypeError) as err:
-            errmsg = "OceanStor response lacks resulting status: %s" % response
+            errmsg = f"OceanStor response lacks resulting status: {response}"
             fancylogger.getLogger().raiseException(errmsg, exception=err.__class__)
 
         try:
@@ -238,8 +238,7 @@ class OceanStorClient(Client):
             if "suggestion" in result:
                 ec_msg_desc += " " + result["suggestion"]
 
-        ec_msg = "%s (%s)" % (exit_code, ec_msg_desc)
-        ec_full_msg = "OceanStor query returned exit code: %s" % ec_msg
+        ec_full_msg = f"OceanStor query returned exit code: {exit_code} ({ec_msg_desc})"
         if exit_code != 0:
             fancylogger.getLogger().raiseException(ec_full_msg, exception=RuntimeError)
         else:
@@ -337,7 +336,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         try:
             ostor_account = response["data"][0]
         except IndexError:
-            errmsg = "OceanStor account not found: %s" % account_name
+            errmsg = f"OceanStor account not found: {account_name}"
             self.log.raiseException(errmsg, OceanStorOperationError)
 
         return ostor_account
@@ -420,7 +419,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         except KeyError as err:
             sp_miss = err.args[0]
             sp_avail = ", ".join(storage_pools)
-            errmsg = "Storage pool '%s' not found in OceanStor. Use any of: %s" % (sp_miss, sp_avail)
+            errmsg = f"Storage pool '{sp_miss}' not found in OceanStor. Use any of: {sp_avail}"
             self.log.raiseException(errmsg, KeyError)
 
         # Convert names to IDs
@@ -509,7 +508,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         try:
             return oceanstor_namespaces[account[0]][namespace]
         except (KeyError, IndexError):
-            errmsg = "OceanStor has no information for namespace %s" % (namespace)
+            errmsg = f"OceanStor has no information for namespace {namespace}"
             self.log.raiseException(errmsg, OceanStorOperationError)
             return None
 
@@ -583,8 +582,8 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             try:
                 target_filesystems_id = [int(fs_id) for fs_id in target_filesystems]
             except ValueError:
-                errmsg = "Malformed list of filesystem IDs: %s"
-                self.log.raiseException(errmsg % ", ".join([str(fs_id) for fs_id in target_filesystems]), ValueError)
+                comma_sep_ids = ", ".join([str(fs_id) for fs_id in target_filesystems])
+                self.log.raiseException(f"Malformed list of filesystem IDs: {comma_sep_ids}", ValueError)
             else:
                 # Convert known IDs to names
                 for n, fs_id in enumerate(target_filesystems_id):
@@ -601,7 +600,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         except KeyError as err:
             fs_miss = err.args[0]
             fs_avail = ", ".join(filesystems)
-            errmsg = "Filesystem '%s' not found in OceanStor. Use any of: %s" % (fs_miss, fs_avail)
+            errmsg = f"Filesystem '{fs_miss}' not found in OceanStor. Use any of: {fs_avail}"
             self.log.raiseException(errmsg, KeyError)
 
         # Generate dict of names and IDs
@@ -624,7 +623,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         try:
             return oceanstor_filesystems[filesystem]
         except KeyError:
-            errmsg = "OceanStor has no information for filesystem %s" % (filesystem)
+            errmsg = f"OceanStor has no information for filesystem {filesystem}"
             self.log.raiseException(errmsg, OceanStorOperationError)
             return None
 
@@ -727,7 +726,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         try:
             filesystem_fsets = self.oceanstor_filesets[filesystem_name]
         except KeyError:
-            errmsg = "OceanStor has no fileset information for filesystem %s" % filesystem_name
+            errmsg = f"OceanStor has no fileset information for filesystem {filesystem_name}"
             self.log.raiseException(errmsg, OceanStorOperationError)
 
         # Convert VSC fileset name to OceanStor ones
@@ -753,7 +752,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         try:
             fileset_name = self.oceanstor_filesets[filesystem_name][fileset_id]["name"]
         except KeyError:
-            errmsg = "Fileset ID '%s' not found in OceanStor filesystem '%s'" % (fileset_id, filesystem_name)
+            errmsg = f"Fileset ID '{fileset_id}' not found in OceanStor filesystem '{filesystem_name}'"
             self.log.raiseException(errmsg, OceanStorOperationError)
 
         # Convert non-standard names to be VSC compliant
@@ -783,7 +782,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                 fileset_id = quota_obj.parentId
 
         if fileset_id is None:
-            errmsg = "Fileset quota '%s' not found in OceanStor filesystem '%s'" % (quota_id, filesystem_name)
+            errmsg = f"Fileset quota '{quota_id}' not found in OceanStor filesystem '{filesystem_name}'"
             self.log.raiseException(errmsg, OceanStorOperationError)
 
         self.log.debug("Quota '%s' is attached to fileset: %s", quota_id, fileset_id)
@@ -804,7 +803,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         elif quota_id in quotas[filesystem_name][Typ2Param.GRP.value]:
             usrgrp_quota = quotas[filesystem_name][Typ2Param.GRP.value][quota_id]
         else:
-            errmsg = "User/Group quota '%s' not found in OceanStor filesystem '%s'" % (quota_id, filesystem_name)
+            errmsg = f"User/Group quota '{quota_id}' not found in OceanStor filesystem '{filesystem_name}'"
             self.log.raiseException(errmsg, OceanStorOperationError)
 
         owner_id = self.vsc.uid_to_uid_number(usrgrp_quota.ownerName)
@@ -859,7 +858,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                 fs_nfs_shares = {ns["id"]: ns for ns in response["data"]}
                 nfs_shares[fs_name] = fs_nfs_shares
 
-            nfs_desc = ["'%s'" % ns["description"] for ns in nfs_shares[fs_name].values()]
+            nfs_desc = [f"'{ns['description']}'" for ns in nfs_shares[fs_name].values()]
             self.log.debug("%sNFS shares in OceanStor filesystem '%s': %s", dbg_prefix, fs_name, ", ".join(nfs_desc))
 
         # Store all NFS shares in selected filesystems
@@ -925,7 +924,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                 share_client = {nc["id"]: nc for nc in response["data"]}
                 nfs_clients[ns_id] = share_client
 
-            nc_access_name = ["'%s'" % nc["access_name"] for nc in nfs_clients[ns_id].values()]
+            nc_access_name = [f"'{nc['access_name']}'" for nc in nfs_clients[ns_id].values()]
             self.log.debug(
                 "%sNFS clients for OceanStor NFS share ID '%s': %s", dbg_prefix, ns_id, ", ".join(nc_access_name)
             )
@@ -953,7 +952,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         try:
             nfs_servers = [IPv4Address(ip) for ip in nfs_servers]
         except AddressValueError:
-            errmsg = "Received malformed server IPs from OceanStor: %s" % comma_sep_ips
+            errmsg = f"Received malformed server IPs from OceanStor: {comma_sep_ips}"
             self.log.raiseException(errmsg, OceanStorOperationError)
         else:
             self.log.debug("NFS servers in OceanStor: %s", comma_sep_ips)
@@ -998,7 +997,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                         server_ip_str = server_ip_str.decode("utf-8")
                     server_ip = IPv4Address(server_ip_str)
                 except AddressValueError:
-                    errmsg = "Error converting address of NFS server to an IPv4: %s" % server_address
+                    errmsg = f"Error converting address of NFS server to an IPv4: {server_address}"
                     self.log.raiseException(errmsg, OceanStorOperationError)
 
                 oceanstor_nfs_servers = self.list_nfs_servers()
@@ -1010,8 +1009,10 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                         dbgmsg = "Local NFS mount '%s' is served by OceanStor and shares object ID: %s"
                         self.log.debug(dbgmsg, mount_point, oceanstor_tag)
                     else:
-                        errmsg = "NFS mount '%s' served from OceanStor '%s' shares unknown path '%s'"
-                        errmsg = errmsg % (mount_point, str(server_ip), share_path)
+                        errmsg = (
+                            f"NFS mount '{mount_point}' served from OceanStor '{str(server_ip)}' "
+                            f"shares unknown path '{share_path}'"
+                        )
                         self.log.raiseException(errmsg, OceanStorOperationError)
 
             # Add filesystem name in OceanStor to all mounts (even if None)
@@ -1027,12 +1028,12 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         # Sanity checks of local path
         if not self.exists(local_path):
-            errmsg = "Path '%s' does not exist in local system."
-            self.log.raiseException(errmsg % local_path, OceanStorOperationError)
+            errmsg = f"Path '{local_path}' does not exist in local system."
+            self.log.raiseException(errmsg, OceanStorOperationError)
 
         if not os.path.isdir(local_path):
-            errmsg = "Path '%s' is not a directory. Cannot identify OceanStor object."
-            self.log.raiseException(errmsg % local_path, OceanStorOperationError)
+            errmsg = f"Path '{local_path}' is not a directory. Cannot identify OceanStor object."
+            self.log.raiseException(errmsg, OceanStorOperationError)
 
         local_path = os.path.realpath(local_path)  # resolve symlinks
 
@@ -1042,7 +1043,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         # Check NFS mount source
         oceanstor_id = local_fs[self.localfilesystemnaming.index(LOCAL_FS_OCEANSTOR)]
         if oceanstor_id is None:
-            errmsg = "NFS mount of '%s' is not from OceanStor" % local_path
+            errmsg = f"NFS mount of '{local_path}' is not from OceanStor"
             self.log.raiseException(errmsg, OceanStorOperationError)
 
         # OceanStor IDs
@@ -1052,8 +1053,8 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         local_mount = local_fs[self.localfilesystemnaming.index("mountpoint")]
         local_path_relative = os.path.relpath(local_path, start=local_mount)
         if local_path_relative.startswith(".."):
-            errmsg = "Local path '%s' was resolved outside mountpoint boundaries '%s'"
-            self.log.raiseException(errmsg % (local_path_relative, local_mount), OceanStorOperationError)
+            errmsg = f"Local path '{local_path_relative}' was resolved outside mountpoint boundaries '{local_mount}'"
+            self.log.raiseException(errmsg, OceanStorOperationError)
         elif local_path_relative == ".":
             local_path_relative = ""
 
@@ -1139,8 +1140,8 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         for banned_fs in BANNED_FILESET_NAMES:
             banned_fs_name = banned_fs[0][0]
             if banned_fs_name.match(ostor_dtree_name):
-                errmsg = "Cannot create fileset with forbidden name: %s"
-                self.log.raiseException(errmsg % (ostor_dtree_name), OceanStorOperationError)
+                errmsg = f"Cannot create fileset with forbidden name: {ostor_dtree_name}"
+                self.log.raiseException(errmsg, OceanStorOperationError)
 
         if fileset_name is None:
             vsc_fileset_name = ostor_dtree_name
@@ -1149,13 +1150,18 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         # Check existence of path in local filesystem
         if self.exists(dtree_fullpath):
-            errmsg = "Path of new fileset in '%s' validated as '%s' but it already exists."
-            self.log.raiseException(errmsg % (new_fileset_path, dtree_fullpath), OceanStorOperationError)
+            errmsg = (
+                f"Path of new fileset in '{new_fileset_path}' validated as '{dtree_fullpath}' but it already exists."
+            )
+            self.log.raiseException(errmsg, OceanStorOperationError)
 
         dtree_parentdir = os.path.dirname(dtree_fullpath)
         if not self.exists(dtree_parentdir):
-            errmsg = "Parent directory '%s' of new fileset '%s' does not exist. It will not be created automatically."
-            self.log.raiseException(errmsg % (dtree_parentdir, dtree_fullpath), OceanStorOperationError)
+            errmsg = (
+                f"Parent directory '{dtree_parentdir}' of new fileset '{dtree_fullpath}' does not exist. "
+                f"It will not be created automatically."
+            )
+            self.log.raiseException(errmsg, OceanStorOperationError)
 
         # Identify local mounted filesystem
         ostor_fs_id, ostor_dtree_id, _, ostor_parentdir = self._identify_local_path(dtree_parentdir)
@@ -1167,13 +1173,18 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             self.log.debug("NFS mount '%s' contains OceanStor filesystem '%s'", dtree_fullpath, ostor_fs_name)
         else:
             # this NFS mount contains a dtree fileset
-            errmsg = "NFS mount '%s' is already a dtree fileset (%s@%s). Nested dtrees are not allowed in OceanStor."
-            self.log.raiseException(errmsg % (dtree_fullpath, ostor_fs_id, ostor_dtree_id), OceanStorOperationError)
+            errmsg = (
+                f"NFS mount '{dtree_fullpath}' is already a dtree fileset ({ostor_fs_id}@{ostor_dtree_id}). "
+                f"Nested dtrees are not allowed in OceanStor."
+            )
+            self.log.raiseException(errmsg, OceanStorOperationError)
 
         # Send API request to create the new dtree fileset
-        dbgmsg = "Sending request for new dtree fileset %s in OceanStor filesystem '%s' with parent directory '%s'"
-        new_dtree_name = "'%s' (VSC: %s)" % (ostor_dtree_name, vsc_fileset_name)
-        self.log.debug(dbgmsg, new_dtree_name, ostor_fs_name, ostor_parentdir)
+        dbgmsg = (
+            f"Sending request for new dtree fileset '{ostor_dtree_name}' (VSC: {vsc_fileset_name}) "
+            f"in OceanStor filesystem '{ostor_fs_name}' with parent directory '{ostor_parentdir}'"
+        )
+        self.log.debug(dbgmsg)
 
         self.make_fileset_api(ostor_dtree_name, ostor_fs_name, parent_dir=ostor_parentdir)
 
@@ -1190,8 +1201,8 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                 if stor.backend == LOCAL_FS_OCEANSTOR and dtree_fullpath.startswith(stor.backend_mount_point)
             ][0]
         except IndexError:
-            errmsg = "Could not find VSC storage for new fileset '%s' at: %s"
-            self.log.raiseException(errmsg % (ostor_dtree_name, ostor_parentdir), OceanStorOperationError)
+            errmsg = f"Could not find VSC storage for new fileset '{ostor_dtree_name}' at: {ostor_parentdir}"
+            self.log.raiseException(errmsg, OceanStorOperationError)
         else:
             if ostor_dtree_name[1:3] == VO_INFIX:
                 block_hard = vsc_fileset_storage.quota_vo
@@ -1227,23 +1238,23 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         # Check filesystem presence
         if filesystem_name not in self.oceanstor_filesets:
-            errmsg = "Requested filesystem '%s' for new dtree fileset '%s' not found."
-            self.log.raiseException(errmsg % (filesystem_name, fileset_name), OceanStorOperationError)
+            errmsg = f"Requested filesystem '{filesystem_name}' for new dtree fileset '{fileset_name}' not found."
+            self.log.raiseException(errmsg, OceanStorOperationError)
 
         # Check if a dtree fileset with this name alreay exists
         for dt in self.oceanstor_filesets[filesystem_name].values():
             if dt["name"] == fileset_name:
-                errmsg = "Found existing dtree fileset '%s' with same name as new one '%s'"
-                self.log.raiseException(errmsg % (dt["name"], fileset_name), OceanStorOperationError)
+                errmsg = f"Found existing dtree fileset '{dt['name']}' with same name as new one '{fileset_name}'"
+                self.log.raiseException(errmsg, OceanStorOperationError)
 
         # Check if OceanStor name constrains for dtrees are met
         unallowed_name_chars = re.compile(r"[^a-zA-Z0-9._]")
         if unallowed_name_chars.search(fileset_name):
-            errmsg = "Name of new dtree fileset contains invalid characters: %s"
-            self.log.raiseException(errmsg % fileset_name, OceanStorOperationError)
+            errmsg = f"Name of new dtree fileset contains invalid characters: {fileset_name}"
+            self.log.raiseException(errmsg, OceanStorOperationError)
         elif len(fileset_name) > 255:
-            errmsg = "Name of new dtree fileset is too long (max. 255 characters): %s"
-            self.log.raiseException(errmsg % fileset_name, OceanStorOperationError)
+            errmsg = f"Name of new dtree fileset is too long (max. 255 characters): {fileset_name}"
+            self.log.raiseException(errmsg, OceanStorOperationError)
         else:
             self.log.debug("Validated name of new dtree fileset: %s", fileset_name)
 
@@ -1333,7 +1344,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         except KeyError as err:
             qa_miss = err.args[0]
             qa_avail = ", ".join(quota)
-            errmsg = "Quota attribute '%s' not found. List of available attributes: %s" % (qa_miss, qa_avail)
+            errmsg = f"Quota attribute '{qa_miss}' not found. List of available attributes: {qa_avail}"
             fancylogger.getLogger().raiseException(errmsg, KeyError)
 
         # Extra filesetname attribute needed by AP
@@ -1412,7 +1423,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                 default_quotas[fs_name] = fs_default_quotas
                 quotas[fs_name] = fs_quotas
 
-            quota_count = ["%s = %s" % (qt.name, len(quotas[fs_name][qt.name])) for qt in QuotaType]
+            quota_count = [f"{qt.name} = {len(quotas[fs_name][qt.name])}" for qt in QuotaType]
             self.log.debug(
                 "%sQuota types for OceanStor filesystem '%s': %s", dbg_prefix, fs_name, ", ".join(quota_count)
             )
@@ -1440,11 +1451,11 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         quota_path = self._sanity_check(obj)
         if not self.dry_run and not self.exists(quota_path):
-            errmsg = "getQuota: can't get quota on non-existing path '%s'" % quota_path
+            errmsg = f"getQuota: can't get quota on non-existing path '{quota_path}'"
             self.log.raiseException(errmsg, OceanStorOperationError)
 
         if typ not in [qt.name for qt in QuotaType]:
-            errmsg = "getQuota: unknown quota type '%s'" % typ
+            errmsg = f"getQuota: unknown quota type '{typ}'"
             self.log.raiseException(errmsg, OceanStorOperationError)
 
         # Identify OceanStor object in path
@@ -1473,8 +1484,11 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
             if len(fileset) > 1:
                 # there cannot be more than one match for any path
-                errmsg = "getQuota: found multiple filesets mathing path '%s' in OceanStor filesystem '%s': %s"
-                self.log.raiseException(errmsg % (quota_path, ostor_mount, ",".join(fileset)), OceanStorOperationError)
+                errmsg = (
+                    f"getQuota: found multiple filesets mathing path '{quota_path}' "
+                    f"in OceanStor filesystem '{ostor_mount}': {', '.join(fileset)}"
+                )
+                self.log.raiseException(errmsg, OceanStorOperationError)
             else:
                 # no fileset found, continue looking up the path
                 dbgmsg = "getQuota: no fileset found matching path '%s' in OceanStor filesystem '%s'"
@@ -1487,7 +1501,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                 parent_id = ostor_fs_id
             else:
                 # mount point is a dtree fileset
-                parent_id = "%s@%s" % (ostor_fs_id, ostor_dtree_id)
+                parent_id = f"{ostor_fs_id}@{ostor_dtree_id}"
             self.log.debug("getQuota: quota path is root of NFS mount for OceanStor object: %s", parent_id)
 
         # Find quotas attached to parent object
@@ -1588,11 +1602,11 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         quota_path = self._sanity_check(obj)
         if not self.dry_run and not self.exists(quota_path):
-            errmsg = "setQuota: can't set quota on non-existing path '%s'" % quota_path
+            errmsg = f"setQuota: can't set quota on non-existing path '{quota_path}'"
             self.log.raiseException(errmsg, OceanStorOperationError)
 
         if typ not in [qt.name for qt in QuotaType]:
-            errmsg = "setQuota: unknown quota type '%s'" % typ
+            errmsg = f"setQuota: unknown quota type '{typ}'"
             self.log.raiseException(errmsg, OceanStorOperationError)
 
         # Check existing quotas on local object
@@ -1656,8 +1670,8 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         if typ in ["user", "group"]:
             # settings for user/group quotas
             if who is None:
-                errmsg = "Cannot ser user/group quota on '%s', account information missing."
-                self.log.raiseException(errmsg % quota_parent, OceanStorOperationError)
+                errmsg = f"Cannot ser user/group quota on '{quota_parent}', account information missing."
+                self.log.raiseException(errmsg, OceanStorOperationError)
 
             query_params["usr_grp_owner_name"] = str(who)
 
@@ -1666,7 +1680,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                 query_params["usr_grp_type"] = 1
             else:
                 # LDAP user/group
-                usr_grp_type = "domain_%s" % typ
+                usr_grp_type = f"domain_{typ}"
                 query_params["usr_grp_type"] = OCEANSTOR_QUOTA_USER_TYPE[usr_grp_type]
                 query_params["domain_type"] = OCEANSTOR_QUOTA_DOMAIN_TYPE["LDAP"]
 
@@ -1717,8 +1731,8 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             if hard is None:
                 hard = int(soft * OCEANSTOR_QUOTA_FACTOR)
             elif hard < soft:
-                errmsg = "setQuota: can't set a hard limit %s lower than soft limit %s"
-                self.log.raiseException(errmsg % (hard, soft), OceanStorOperationError)
+                errmsg = f"setQuota: can't set a hard limit {hard} lower than soft limit {soft}"
+                self.log.raiseException(errmsg, OceanStorOperationError)
 
             # Space quota limits
             query_params["space_soft_quota"] = soft
@@ -1729,8 +1743,8 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
             if inode_hard is None:
                 inode_hard = int(inode_soft * OCEANSTOR_QUOTA_FACTOR)
             elif inode_hard < inode_soft:
-                errmsg = "setQuota: can't set hard inode limit %s lower than soft inode limit %s"
-                self.log.raiseException(errmsg % (inode_hard, inode_soft), OceanStorOperationError)
+                errmsg = f"setQuota: can't set hard inode limit {inode_hard} lower than soft inode limit {inode_soft}"
+                self.log.raiseException(errmsg, OceanStorOperationError)
 
             # Inodes quota limits
             query_params["file_soft_quota"] = inode_soft
@@ -1788,11 +1802,11 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
 
         quota_path = self._sanity_check(obj)
         if not self.dry_run and not self.exists(quota_path):
-            errmsg = "setGrace: can't set grace on non-existing path '%s'" % quota_path
+            errmsg = f"setGrace: can't set grace on non-existing path '{quota_path}'"
             self.log.raiseException(errmsg, OceanStorOperationError)
 
         if typ not in [qt.name for qt in QuotaType]:
-            errmsg = "setGrace: unknown quota type '%s'" % typ
+            errmsg = f"setGrace: unknown quota type '{typ}'"
             self.log.raiseException(errmsg, OceanStorOperationError)
 
         # Find all existing quotas attached to local object
@@ -1808,7 +1822,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
                 )
                 self.log.debug(dbgmsg, typ, who, quota_parent)
             else:
-                errmsg = "setGrace: %s quota of '%s' not found" % (typ, quota_path)
+                errmsg = f"setGrace: {typ} quota of '{quota_path}' not found"
                 self.log.raiseException(errmsg, OceanStorOperationError)
 
         # Set grace period
@@ -1988,7 +2002,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         if fileset is not None:
             dtree = self.get_fileset_info(filesystem, fileset)
             if dtree is None:
-                err_msg = "Snapshot query failed: fileset '%s' not found in filesystem '%s'" % (filesystem, fileset)
+                err_msg = f"Snapshot query failed: fileset '{fileset}' not found in filesystem '{filesystem}'"
                 self.log.raiseException(err_msg, OceanStorOperationError)
             filter_json["dtree_id"] = dtree["id"]
 
@@ -2098,7 +2112,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         Return unique snapshot name for a given fileset
         """
         # prefix filset name to snapshot name
-        fileset_snapshot = "%s_%s" % (fileset, snapshot_basename)
+        fileset_snapshot = f"{fileset}_{snapshot_basename}"
 
         dbgmsg = "Snapshot name of dtree fileset '%s' changed from '%s' to '%s' to avoid name collision"
         self.log.debug(dbgmsg, fileset, snapshot_basename, fileset_snapshot)

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -228,13 +228,17 @@ class OceanStorClient(Client):
             # Some queries generate a response with an int result
             # e.g. GET 'data_service/storagepool'
             exit_code = result
-            ec_msg = str(exit_code)
+            ec_msg_desc = ""
+            if "data" in response:
+                ec_msg_desc = response["data"]["errorMsg"]
+                if "suggestion" in response["data"]:
+                    ec_msg_desc += " " + response["data"]["suggestion"]
         else:
             ec_msg_desc = result["description"]
             if "suggestion" in result:
                 ec_msg_desc += " " + result["suggestion"]
-            ec_msg = "%s (%s)" % (result["code"], ec_msg_desc)
 
+        ec_msg = "%s (%s)" % (exit_code, ec_msg_desc)
         ec_full_msg = "OceanStor query returned exit code: %s" % ec_msg
         if exit_code != 0:
             fancylogger.getLogger().raiseException(ec_full_msg, exception=RuntimeError)

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -503,7 +503,7 @@ class OceanStorOperations(with_metaclass(Singleton, PosixOperations)):
         @raise OceanStorOperationError: if there is no namespace with the given name
         """
         oceanstor_namespaces = self.list_namespaces()
-        account = [ns for ns in oceanstor_namespaces if namespace in oceanstor_namespaces[ns]]
+        account = [acc for acc in oceanstor_namespaces if namespace in oceanstor_namespaces[acc]]
 
         try:
             return oceanstor_namespaces[account[0]][namespace]

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ if sys.version_info < (3, 4):
     install_requires.append('enum34')
 
 PACKAGE = {
-    'version': '0.7.0',
+    'version': '0.8.0',
     'author': [ad],
     'maintainer': [ad],
     'setup_requires': ['vsc-install'],

--- a/test/10-oceanstor.py
+++ b/test/10-oceanstor.py
@@ -231,7 +231,7 @@ def api_response_snapshots_side_effect(filter=None, *args, **kwargs):
     return (0, response)
 
 
-def api_response_account_side_effect(filter=None, *args):
+def api_response_account_side_effect(filter=None, **kwargs):
     """
     Mock GET responses of account/accounts depending on the filesystem name
     """
@@ -278,6 +278,16 @@ class StorageTest(TestCase):
         }
         self.assertEqual(O.get_account_info("test"), account_reference)
         self.assertRaises(oceanstor.OceanStorOperationError, O.get_account_info, "nonexistent")
+
+    @mock.patch("vsc.filesystem.oceanstor.OceanStorRestClient", rest_client)
+    def test_list_active_accounts(self):
+        O = oceanstor.OceanStorOperations(*FAKE_INIT_PARAMS)
+        accounts_reference = [
+            ("system", "0"),
+            ("test", "0000000001"),
+            ("oceanstor_account", "0000000002"),
+        ]
+        self.assertEqual(O.list_active_accounts(), accounts_reference)
 
     @mock.patch("vsc.filesystem.oceanstor.OceanStorRestClient", rest_client)
     def test_list_storage_pools(self):

--- a/test/10-oceanstor.py
+++ b/test/10-oceanstor.py
@@ -221,15 +221,15 @@ class StorageTest(TestCase):
     rest_client = mock.Mock()
     session = rest_client.return_value
     # static queries
-    session.account.accounts.get.return_value = (0, API_RESPONSE["account.accounts"])
-    session.data_service.storagepool.get.return_value = (0, API_RESPONSE["data_service.storagepool"])
-    session.converged_service.namespaces.get.return_value = (0, API_RESPONSE["converged_service.namespaces"])
-    session.file_service.snapshots.post.return_value = (0, API_RESPONSE["file_service.snapshots.post"])
-    session.file_service.snapshots.delete.return_value = (0, API_RESPONSE["file_service.snapshots.delete"])
+    session.api.v2.account.accounts.get.return_value = (0, API_RESPONSE["account.accounts"])
+    session.api.v2.data_service.storagepool.get.return_value = (0, API_RESPONSE["data_service.storagepool"])
+    session.api.v2.converged_service.namespaces.get.return_value = (0, API_RESPONSE["converged_service.namespaces"])
+    session.api.v2.file_service.snapshots.post.return_value = (0, API_RESPONSE["file_service.snapshots.post"])
+    session.api.v2.file_service.snapshots.delete.return_value = (0, API_RESPONSE["file_service.snapshots.delete"])
     # queries related to dtrees have variable outcome depending on arguments
-    session.get.side_effect = api_response_get_side_effect
-    session.file_service.dtrees.get.side_effect = api_response_dtree_side_effect
-    session.file_service.snapshots.get.side_effect = api_response_snapshots_side_effect
+    session.api.v2.get.side_effect = api_response_get_side_effect
+    session.api.v2.file_service.dtrees.get.side_effect = api_response_dtree_side_effect
+    session.api.v2.file_service.snapshots.get.side_effect = api_response_snapshots_side_effect
 
     @mock.patch("vsc.filesystem.oceanstor.OceanStorRestClient", rest_client)
     def test_list_storage_pools(self):

--- a/test/10-oceanstor.py
+++ b/test/10-oceanstor.py
@@ -155,6 +155,22 @@ API_RESPONSE = {
             "description": "",
         },
     },
+    "converged_service.snapshots.post": {
+        "data": {
+            "id": "287762808832@1335",
+        },
+        "result": {
+            "code": 0,
+            "description": "",
+        },
+    },
+    "converged_service.snapshots.delete": {
+        "data": {},
+        "result": {
+            "code": 0,
+            "description": "",
+        },
+    },
     "file_service.dtrees": {
         "data": [
             {
@@ -353,11 +369,13 @@ class StorageTest(TestCase):
     session.api.v2.data_service.storagepool.get.return_value = (0, API_RESPONSE["data_service.storagepool"])
     session.api.v2.file_service.snapshots.post.return_value = (0, API_RESPONSE["file_service.snapshots.post"])
     session.api.v2.file_service.snapshots.delete.return_value = (0, API_RESPONSE["file_service.snapshots.delete"])
+    session.api.v2.converged_service.snapshots.post.return_value = (0, API_RESPONSE["converged_service.snapshots.post"])
+    session.api.v2.converged_service.snapshots.delete.return_value = (0, API_RESPONSE["converged_service.snapshots.delete"])
     # queries related to dtrees have variable outcome depending on arguments
     session.api.v2.get.side_effect = api_response_get_side_effect
+    session.api.v2.account.accounts.get.side_effect = api_response_account_side_effect
     session.api.v2.file_service.dtrees.get.side_effect = api_response_dtree_side_effect
     session.api.v2.file_service.snapshots.get.side_effect = api_response_snapshots_side_effect
-    session.api.v2.account.accounts.get.side_effect = api_response_account_side_effect
     session.api.v2.converged_service.namespaces.get.side_effect = api_response_namespaces_side_effect
     session.api.v2.converged_service.snapshots.get.side_effect = api_response_namespace_snapshots_side_effect
 
@@ -625,6 +643,24 @@ class StorageTest(TestCase):
         snap_reference = ["SNAP_OBJ_01"]
         self.assertEqual(O.list_namespace_snapshots("object"), snap_reference)
         self.assertRaises(oceanstor.OceanStorOperationError, O.list_namespace_snapshots, "nonexistent")
+
+    @mock.patch("vsc.filesystem.oceanstor.OceanStorRestClient", rest_client)
+    def test_create_namespace_snapshot(self):
+        O = oceanstor.OceanStorOperations(*FAKE_INIT_PARAMS)
+        self.assertEqual(O.create_namespace_snapshot("object", "NEW_SNAPSHOT"), True)
+        self.assertEqual(O.create_namespace_snapshot("object", "SNAP_OBJ_01"), 0)
+        self.assertRaises(
+            oceanstor.OceanStorOperationError, O.create_namespace_snapshot, "nonexistent", "NEW_SNAPSHOT"
+        )
+
+    @mock.patch("vsc.filesystem.oceanstor.OceanStorRestClient", rest_client)
+    def test_delete_namespace_snapshot(self):
+        O = oceanstor.OceanStorOperations(*FAKE_INIT_PARAMS)
+        self.assertEqual(O.delete_namespace_snapshot("object", "SNAP_OBJ_01"), True)
+        self.assertEqual(O.delete_namespace_snapshot("object", "NONEXISTENT"), 0)
+        self.assertRaises(
+            oceanstor.OceanStorOperationError, O.delete_namespace_snapshot, "nonexistent", "SNAP_TEST_01"
+        )
 
     @mock.patch("vsc.filesystem.oceanstor.OceanStorRestClient", rest_client)
     def test_list_snapshots(self):

--- a/test/10-oceanstor.py
+++ b/test/10-oceanstor.py
@@ -394,6 +394,18 @@ class StorageTest(TestCase):
         self.assertEqual(O.list_namespaces(update=True), ns_ref_full)
 
     @mock.patch("vsc.filesystem.oceanstor.OceanStorRestClient", rest_client)
+    def test_get_namespace_info(self):
+        O = oceanstor.OceanStorOperations(*FAKE_INIT_PARAMS)
+        ns_test = {
+            "id": 10,
+            "name": "test",
+            "storage_pool_id": 0,
+            "account_id": "0000000002",
+        }
+        self.assertEqual(O.get_namespace_info("test"), ns_test)
+        self.assertRaises(oceanstor.OceanStorOperationError, O.get_filesystem_info, "nonexistent")
+
+    @mock.patch("vsc.filesystem.oceanstor.OceanStorRestClient", rest_client)
     def test_list_filesystems(self):
         O = oceanstor.OceanStorOperations(*FAKE_INIT_PARAMS)
 


### PR DESCRIPTION
Changelog:
* set `OceanStorRestClient` URL to the root of the API interface to be able to access other interfaces beyond `api/v2`
* add method to list active accounts
* add methods to list namespaces and get information about namespaces
* refactor method `list_filesystems()` to leverage `list_namespaces()`
* add method to list snapshots of a namespace
* add methods to create and delete snapshots of a namespace
* add unit tests for all new methods