### PR TITLE
add support to list buckets (AB#18014)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ if sys.version_info < (3, 4):
     install_requires.append('enum34')
 
 PACKAGE = {
-    'version': '0.8.0',
+    'version': '0.8.1',
     'author': [ad],
     'maintainer': [ad],
     'setup_requires': ['vsc-install'],

--- a/test/10-oceanstor.py
+++ b/test/10-oceanstor.py
@@ -517,7 +517,7 @@ class StorageTest(TestCase):
                 },
             },
         }
-        O.oceanstor_namespaces = ns_outdated
+        O.oceanstor_account_namespaces = ns_outdated
         self.assertEqual(O.list_namespaces(), ns_outdated)
         self.assertEqual(O.list_namespaces(update=True), ns_ref_full)
 


### PR DESCRIPTION
Changelog:
* add method `OceanStorOpertations._is_bucket()` to check if a given namespace is a bucket
* add methos `OceanStorOperations.list_buckets()` to list buckets using the same format as `list_namespaces()`
* add unit tests for the new methods