### PR TITLE
fix inode quota limits on new user quotas

### DIFF
--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -1709,12 +1709,6 @@ class OceanStorOperations(PosixOperations, metaclass=Singleton):
         quota_limits = {"soft": soft, "hard": hard, "inode_soft": inode_soft, "inode_hard": inode_hard}
         self._set_quota(who=fileset_name, obj=fileset_path, typ="fileset", **quota_limits)
 
-        # TODO: remove once OceanStor supports creating user quotas on non-empty filesets
-        # User quotas in VOs are temporarily frozen to 100% of VO fileset quota
-        if "brussel/vo" in fileset_path:
-            # Update default user quota in this VO to 100% of fileset quota
-            self._set_quota(who="*", obj=fileset_path, typ=Typ2Param.USR.value, **quota_limits)
-
     def _set_quota(self, who, obj, typ=Typ2Param.USR.value, **kwargs):
         """
         Set quota on a given local object.

--- a/lib/vsc/filesystem/oceanstor.py
+++ b/lib/vsc/filesystem/oceanstor.py
@@ -1744,9 +1744,15 @@ class OceanStorOperations(PosixOperations, metaclass=Singleton):
                    kwargs["inode_hard"] = default_quota[0].filesLimit
                    kwargs["inode_soft"] = default_quota[0].filesQuota
                 except (KeyError, IndexError):
+                    # move along, not every object and type of quota has a default quota
                     self.log.warning(
                         f"setQuota: failed to retrieve default inode quotas from parent '{quota_parent}' "
-                        f"of '{quota_path}'"
+                        f"quota of '{quota_path}'"
+                    )
+                else:
+                    self.log.debug(
+                        f"setQuota: applying default inode limit of {kwargs['inode_hard']} "
+                        f"from parent '{quota_parent}' to new quota for '{who}' in '{quota_path}'"
                     )
             self._new_quota_api(quota_parent, typ=typ, who=who, **kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ install_requires = [
 ]
 
 PACKAGE = {
-    'version': '0.8.6',
+    'version': '0.8.7',
     'author': [ad],
     'maintainer': [ad],
     'setup_requires': ['vsc-install'],


### PR DESCRIPTION
Fixes AD#24017

`vsc-administration` can set new user quotas for users that do not have any files of their own yet in the fileset. Those new quotas are set without any inode limits, and since the user has no files, there is no pre-existing quota in oceanstor. Therefore, the new quota is created with a default inode limit of 1M.

This PR improves handling of such a case by retrieving the inode limits from the corresponding default quota (if any) and applying those to the new quota request.

Example:

See `file_xxx_quota` in the following cases:

BEFORE CASE:
```
(dryrun) New quota creation query: {'space_unit_type': 0, 'space_soft_quota': 51002736640,
'space_hard_quota': 53687091200, 'file_soft_quota': 998643, 'file_hard_quota': 1048575,
'parent_id': '00@0000', 'parent_type': 0000, 'quota_type': 2, 'usr_grp_owner_name': 'vscxxxxx', 
'usr_grp_type': 3, 'domain_type': 2}
```

AFTER CASE:
```
(dryrun) New quota creation query: {'space_unit_type': 0, 'space_soft_quota': 51002736640, 
'space_hard_quota': 53687091200, 'file_soft_quota': 9523809, 'file_hard_quota': 10000000, 
'parent_id': '00@0000', 'parent_type': 0000, 'quota_type': 2, 'usr_grp_owner_name': 'vscxxxxx', 
'usr_grp_type': 3, 'domain_type': 2}
```